### PR TITLE
Add more Python-visible reflection

### DIFF
--- a/capnp/capnp.pyx
+++ b/capnp/capnp.pyx
@@ -380,6 +380,11 @@ cdef class _StructSchema:
                                       for i in xrange(nfields))
             return self.__fieldnames
 
+    property node:
+        """The raw schema node"""
+        def __get__(self):
+            return _DynamicStructReader()._init(self.thisptr.getProto(), None)
+
 cdef class _ParsedSchema:
     cdef C_ParsedSchema thisptr
     cdef _init(self, C_ParsedSchema other):

--- a/capnp/capnp_cpp.pxd
+++ b/capnp/capnp_cpp.pxd
@@ -43,7 +43,6 @@ cdef extern from "capnp/schema.h" namespace " ::capnp":
             uint size()
             Field operator[](uint index)
 
-        Node.Reader getProto()
         FieldList getFields()
         Field getFieldByName(char * name)
 


### PR DESCRIPTION
This is probably not the most efficient thing in the world, nor is it
really beautiful, but it's fun.  Now you can do this in ipython with
liberal use of the tab key:

In [2]: import capnp

In [3]: s = capnp.load('/home/luto/devel/capnp/test.capnp')

In [4]: s.
s.CxxgenArgs   s.Double2D     s.ExpRanges    s.Exposures    s.StaticState  s.cxxgen       s.fxgraphnode  

In [4]: s.Double2D.Schema
Out[4]: <capnp.capnp._StructSchema at 0x29a2e60>

In [5]: s.Double2D.Schema.
s.Double2D.Schema.fieldnames  s.Double2D.Schema.node        

In [5]: s.Double2D.Schema.node
Out[5]: <capnp.capnp._DynamicStructReader at 0x299d1b8>

In [6]: s.Double2D.Schema.node.
s.Double2D.Schema.node.annotation               s.Double2D.Schema.node.id
s.Double2D.Schema.node.annotations              s.Double2D.Schema.node.interface
s.Double2D.Schema.node.const                    s.Double2D.Schema.node.nestedNodes
s.Double2D.Schema.node.displayName              s.Double2D.Schema.node.schema
s.Double2D.Schema.node.displayNamePrefixLength  s.Double2D.Schema.node.scopeId
s.Double2D.Schema.node.enum                     s.Double2D.Schema.node.struct
s.Double2D.Schema.node.file                     s.Double2D.Schema.node.which

Andy Lutomirski (2):
  Add some useful _StructSchema, reader, and builder methods
  Expose _StructSchema's raw node

 capnp/capnp.pyx     | 42 ++++++++++++++++++++++++++++++++++++++++++
 capnp/capnp_cpp.pxd | 14 +++++---------
 2 files changed, 47 insertions(+), 9 deletions(-)
