### PR TITLE
Add Builder and Reader ABCs for each struct type

### DIFF
--- a/capnp/capnp_cpp.pxd
+++ b/capnp/capnp_cpp.pxd
@@ -60,6 +60,8 @@ cdef extern from "capnp/schema.h" namespace " ::capnp":
 
         Field getFieldByName(char * name)
 
+        int operator == (StructSchema)
+
     cdef cppclass EnumSchema:
         cppclass Enumerant:
             EnumNode.Enumerant.Reader getProto()


### PR DESCRIPTION
This has zero overhead if not used.  I decided that it was simpler
to use ABCs instead of real classes, given that using real classes
offers little benefit.

This also implements == and != for StructSchema objects.

NB: This fails tests, but so does the current develop code.
