### PR TITLE
Remove cython/setuptools version checks since setup will install them.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-try:
-    from Cython.Build import cythonize
-    import Cython
-except ImportError:
-    raise RuntimeError('No cython installed. Please run `pip install cython`')
-
-if Cython.__version__ < '0.19.1':
-    raise RuntimeError('Old cython installed (%s). Please run `pip install -U cython`' % Cython.__version__)
-
-import pkg_resources
-setuptools_version = pkg_resources.get_distribution("setuptools").version
-if setuptools_version < '0.8':
-    raise RuntimeError('Old setuptools installed (%s). Please run `pip install -U setuptools`. Running `pip install pycapnp` will not work alone, since setuptools needs to be upgraded before installing anything else.' % setuptools_version)
-
 from distutils.core import setup
 import os
 import sys


### PR DESCRIPTION
The `setup` call specifies the necessary versions of cython and setuptools so when you pip install it will install them automatically:

https://github.com/jparyani/pycapnp/blob/4a11ffedd943de71a6dce8976c243806a1cafbd1/setup.py#L123

So the explicit checks at the top of `setup.py` are not necessary and cause the pip installation to fail rather than install the necessary versions.
