### PR TITLE
Capnproto 0.6.0

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -35,8 +35,8 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (0,5,3,1)
-libcapnp = "capnproto-c++-%i.%i.%i.%i.tar.gz" % (bundled_version)
+bundled_version = (0,6,0)
+libcapnp = "capnproto-c++-%i.%i.%i.tar.gz" % (bundled_version)
 libcapnp_url = "https://capnproto.org/" + libcapnp
 
 HERE = os.path.dirname(__file__)

--- a/capnp/includes/capnp_cpp.pxd
+++ b/capnp/includes/capnp_cpp.pxd
@@ -101,13 +101,23 @@ ctypedef Promise[PyArray] PyPromiseArray
 
 cdef extern from "kj/time.h" namespace " ::kj":
     cdef cppclass Duration:
-        Duration(int64_t)
+        Duration operator*(int64_t)
+    Duration NANOSECONDS
+    Duration MICROSECONDS
+    Duration MILLISECONDS
+    Duration SECONDS
+    Duration MINUTES
+    Duration HOURS
+    Duration DAYS
     # cdef cppclass TimePoint:
     #     TimePoint(Duration)
     cdef cppclass Timer:
         # int64_t now()
         # VoidPromise atTime(TimePoint time)
         VoidPromise afterDelay(Duration delay)
+
+cdef inline Duration Nanoseconds(int64_t nanos):
+    return NANOSECONDS * nanos
 
 cdef extern from "kj/async-io.h" namespace " ::kj":
     cdef cppclass AsyncIoStream:

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1688,7 +1688,7 @@ cdef class _Timer:
         return self
 
     cpdef after_delay(self, time) except +reraise_kj_exception:
-        return _VoidPromise()._init(self.thisptr.afterDelay(capnp.Duration(time)))
+        return _VoidPromise()._init(self.thisptr.afterDelay(capnp.Nanoseconds(time)))
 
 def getTimer():
     return _Timer()._init(helpers.getTimer(C_DEFAULT_EVENT_LOOP_GETTER().thisptr))

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ from distutils.extension import Extension
 _this_dir = os.path.dirname(__file__)
 
 MAJOR = 0
-MINOR = 5
-MICRO = 12
+MINOR = 6
+MICRO = 0
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 


### PR DESCRIPTION
This seems to get pycapnp building against 0.6.0 for me, addressing https://github.com/capnproto/pycapnp/issues/151.
(Disclaimer: I don't know the code well and don't use the RPC features.)