### PR TITLE
Issue 145: decrement exception object prior to returning.

### DIFF
--- a/capnp/helpers/capabilityHelper.h
+++ b/capnp/helpers/capabilityHelper.h
@@ -66,6 +66,7 @@ void reraise_kj_exception() {
   catch (kj::Exception& exn) {
     auto obj = wrap_kj_exception_for_reraise(exn);
     PyErr_SetObject((PyObject*)obj->ob_type, obj);
+    Py_DECREF(obj);
   }
   catch (const std::exception& exn) {
     PyErr_SetString(PyExc_RuntimeError, exn.what());


### PR DESCRIPTION
KjExceptions are leaked because reraise_kj_exception never releases its refcount.