### PR TITLE
Capnproto 0.6.1 and one less memory leak

### DIFF
--- a/buildutils/bundle.py
+++ b/buildutils/bundle.py
@@ -35,7 +35,7 @@ pjoin = os.path.join
 # Constants
 #-----------------------------------------------------------------------------
 
-bundled_version = (0,6,0)
+bundled_version = (0,6,1)
 libcapnp = "capnproto-c++-%i.%i.%i.tar.gz" % (bundled_version)
 libcapnp_url = "https://capnproto.org/" + libcapnp
 

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1958,9 +1958,6 @@ cdef class _RemotePromise:
             if args_length - defaults_length != 1:
                 raise KjException('Function passed to `then` call must take exactly one argument')
 
-        Py_INCREF(func)
-        Py_INCREF(error_func)
-
         cdef Promise new_promise = Promise()._init(helpers.then(deref(self.thisptr), <PyObject *>func, <PyObject *>error_func), self)
         return Promise()._init(new_promise.thisptr.attach(capnp.makePyRefCounter(<PyObject *>func), capnp.makePyRefCounter(<PyObject *>error_func)), new_promise)
 


### PR DESCRIPTION
Excess reference increment was causing a Python object leak when registering continuations to remote (RPC) promises.
New Capnproto doesn't seem to require additional changes.