### PR TITLE
Instanciate a single bootstrap object per client, add IP tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ sudo: required
 language: python
 
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
+  - 3.5
+  - 3.6
   - pypy
 
 env:

--- a/buildutils/setup_travis.sh
+++ b/buildutils/setup_travis.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-CAPNP_VERSION=0.5.2
+CAPNP_VERSION=0.7.0
 
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -qq update

--- a/buildutils/setup_travis.sh
+++ b/buildutils/setup_travis.sh
@@ -6,9 +6,9 @@ CAPNP_VERSION=0.7.0
 
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get -qq update
-sudo apt-get -qq install g++-4.8 libstdc++-4.8-dev
-sudo update-alternatives --quiet --install /usr/bin/gcc  gcc  /usr/bin/gcc-4.8  60 --slave   /usr/bin/g++  g++  /usr/bin/g++-4.8 --slave   /usr/bin/gcov gcov /usr/bin/gcov-4.8
-sudo update-alternatives --quiet --set gcc /usr/bin/gcc-4.8
+sudo apt-get -qq install g++-5 libstdc++-5-dev
+sudo update-alternatives --quiet --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5 --slave /usr/bin/gcov gcov /usr/bin/gcov-5
+
 
 if ! [ -z "${BUILD_CAPNP}" ]; then
   wget https://capnproto.org/capnproto-c++-${CAPNP_VERSION}.tar.gz && tar xzvf capnproto-c++-${CAPNP_VERSION}.tar.gz && cd capnproto-c++-${CAPNP_VERSION} && ./configure && make -j6 && sudo make install && sudo ldconfig && cd ..

--- a/capnp/helpers/capabilityHelper.h
+++ b/capnp/helpers/capabilityHelper.h
@@ -195,7 +195,7 @@ public:
   PythonInterfaceDynamicImpl(capnp::InterfaceSchema & schema, PyObject * _py_server)
       : capnp::DynamicCapability::Server(schema), py_server(_py_server) {
         GILAcquire gil;
-        Py_INCREF(_py_server);
+        Py_INCREF(py_server);
       }
 
   ~PythonInterfaceDynamicImpl() {

--- a/capnp/helpers/helpers.pxd
+++ b/capnp/helpers/helpers.pxd
@@ -34,7 +34,7 @@ cdef extern from "capnp/helpers/rpcHelper.h":
     Capability.Client bootstrapHelperServer(RpcSystem&)
     RpcSystem makeRpcClientWithRestorer(TwoPartyVatNetwork&, PyRestorer&)
     PyPromise connectServerRestorer(TaskSet &, PyRestorer &, AsyncIoContext *, StringPtr)
-    PyPromise connectServer(TaskSet &, AsyncIoContext *, StringPtr, InterfaceSchema&, PyObject *)
+    PyPromise connectServer(TaskSet &, AsyncIoContext *, StringPtr, PyObject *, InterfaceSchema &)
 
 cdef extern from "capnp/helpers/serialize.h":
     ByteArray messageToPackedBytes(MessageBuilder &, size_t wordCount)

--- a/capnp/helpers/helpers.pxd
+++ b/capnp/helpers/helpers.pxd
@@ -34,7 +34,7 @@ cdef extern from "capnp/helpers/rpcHelper.h":
     Capability.Client bootstrapHelperServer(RpcSystem&)
     RpcSystem makeRpcClientWithRestorer(TwoPartyVatNetwork&, PyRestorer&)
     PyPromise connectServerRestorer(TaskSet &, PyRestorer &, AsyncIoContext *, StringPtr)
-    PyPromise connectServer(TaskSet &, Capability.Client, AsyncIoContext *, StringPtr)
+    PyPromise connectServer(TaskSet &, AsyncIoContext *, StringPtr, InterfaceSchema&, PyObject *)
 
 cdef extern from "capnp/helpers/serialize.h":
     ByteArray messageToPackedBytes(MessageBuilder &, size_t wordCount)

--- a/examples/calculator_server.py
+++ b/examples/calculator_server.py
@@ -133,7 +133,7 @@ given address/port ADDRESS may be '*' to bind to all local addresses.\
 def main():
     address = parse_args().address
 
-    server = capnp.TwoPartyServer(address, bootstrap=CalculatorImpl())
+    server = capnp.TwoPartyServer(address, bootstrap=CalculatorImpl)
     server.run_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
You can specify a callback as `__connect_handler__` class attribute on your bootstrap object (defaults to calling `on_connect` if it's present and callable) to track the user IP and port in case you want/need to. This implies having a single bootstrap object per client, which breaks backwards compatibility (but as I understand it, the proper C++ way is also to instance a bootstrap object for each client).

Feel free to not merge this - it's mostly here as "documentation" for people who need the feature to get an idea how to reach it. It's very possibly still wrong and/or buggy in some places.

Usage is demonstrated on https://github.com/Cheaterman/capnchat/ - I feel like it serves a good purpose as working example (as opposed to the tests and examples we currently have in the codebase - although the Calculator is useful, it cannot demonstrate how multiple clients would interact for instance).

Sorry for not taking the time to adapt a similar system to restorer and to socket-based instantiations of TwoPartyServer. I feel like these two features are kind of deprecated and missing some work (respectively), and I'll instead work on making connection strings work with UDP (possibly using udp:// prefix or something similar) - but that's for another PR.

Thanks for reading! Hope you like this!