### PR TITLE
Rearrange declarations to avoid circular imports.

### DIFF
--- a/capnp/helpers/helpers.pxd
+++ b/capnp/helpers/helpers.pxd
@@ -1,8 +1,8 @@
-from capnp.includes.capnp_cpp cimport Maybe, ReaderOptions, DynamicStruct, Request, Response, PyPromise, VoidPromise, PyPromiseArray, RemotePromise, DynamicCapability, InterfaceSchema, EnumSchema, StructSchema, DynamicValue, Capability, RpcSystem, MessageBuilder, MessageReader, TwoPartyVatNetwork, AnyPointer, DynamicStruct_Builder, WaitScope, AsyncIoContext, StringPtr, TaskSet, Timer
+from capnp.includes.capnp_cpp cimport Maybe, ReaderOptions, DynamicStruct, Request, Response, PyPromise, VoidPromise, PyPromiseArray, RemotePromise, DynamicCapability, InterfaceSchema, EnumSchema, StructSchema, DynamicValue, Capability, RpcSystem, MessageBuilder, MessageReader, TwoPartyVatNetwork, AnyPointer, DynamicStruct_Builder, WaitScope, AsyncIoContext, StringPtr, TaskSet, Timer, AsyncIoStreamReadHelper
 
 from capnp.includes.schema_cpp cimport ByteArray
 
-from non_circular cimport reraise_kj_exception, AsyncIoStreamReadHelper
+from non_circular cimport reraise_kj_exception
 
 from cpython.ref cimport PyObject
 

--- a/capnp/helpers/non_circular.pxd
+++ b/capnp/helpers/non_circular.pxd
@@ -1,5 +1,4 @@
 from cpython.ref cimport PyObject
-from capnp.includes.capnp_cpp cimport AsyncIoStream, WaitScope
 from libcpp cimport bool
 
 cdef extern from "capnp/helpers/capabilityHelper.h":
@@ -18,10 +17,3 @@ cdef extern from "capnp/helpers/rpcHelper.h":
 cdef extern from "capnp/helpers/asyncHelper.h":
     cdef cppclass PyEventPort:
         PyEventPort(PyObject *)
-
-cdef extern from "capnp/helpers/asyncIoHelper.h":
-    cdef cppclass AsyncIoStreamReadHelper:
-        AsyncIoStreamReadHelper(AsyncIoStream *, WaitScope *, size_t)
-        bool poll()
-        size_t read_size()
-        void* read_buffer()

--- a/capnp/includes/capnp_cpp.pxd
+++ b/capnp/includes/capnp_cpp.pxd
@@ -4,8 +4,8 @@ cdef extern from "capnp/helpers/checkCompiler.h":
     pass
 
 from libcpp cimport bool
-from capnp.includes.schema_cpp cimport Node, Data, StructNode, EnumNode, InterfaceNode, MessageBuilder, MessageReader, ReaderOptions
 from capnp.helpers.non_circular cimport PythonInterfaceDynamicImpl, reraise_kj_exception, PyRefCounter, PyEventPort, ErrorHandler
+from capnp.includes.schema_cpp cimport Node, Data, StructNode, EnumNode, InterfaceNode, MessageBuilder, MessageReader, ReaderOptions
 from capnp.includes.types cimport *
 
 cdef extern from "capnp/common.h" namespace " ::capnp":
@@ -517,3 +517,10 @@ cdef extern from "kj/async.h" namespace " ::kj":
         Own[PromiseFulfiller] fulfiller
     PromiseFulfillerPair newPromiseAndFulfiller" ::kj::newPromiseAndFulfiller<void>"()
     PyPromiseArray joinPromises(Array[PyPromise])
+
+cdef extern from "capnp/helpers/asyncIoHelper.h":
+    cdef cppclass AsyncIoStreamReadHelper:
+        AsyncIoStreamReadHelper(AsyncIoStream *, WaitScope *, size_t)
+        bool poll()
+        size_t read_size()
+        void* read_buffer()

--- a/capnp/includes/schema_cpp.pxd
+++ b/capnp/includes/schema_cpp.pxd
@@ -2,7 +2,6 @@
 # distutils: language = c++
 
 from libc.stdint cimport *
-from capnp.includes.capnp_cpp cimport DynamicOrphan
 from capnp.helpers.non_circular cimport reraise_kj_exception
 
 from capnp.includes.types cimport *
@@ -19,6 +18,11 @@ cdef extern from "capnp/dynamic.h" namespace " ::capnp":
 
     cdef cppclass DynamicStruct_Builder" ::capnp::DynamicStruct::Builder":
         pass
+
+cdef extern from "capnp/orphan.h" namespace " ::capnp":
+    cdef cppclass DynamicOrphan" ::capnp::Orphan< ::capnp::DynamicValue>":
+        DynamicValue.Builder get()
+        DynamicValue.Reader getReader()
 
 cdef extern from "capnp/schema.h" namespace " ::capnp":
     cdef cppclass Schema:


### PR DESCRIPTION
Circular imports make importing of pxd's order sensitive, and violating this
order results in hard to understand errors.  As far as I can tell, this
rearrangement removes the circular nature, and has no other side
affects.