### PR TITLE
Rename capnp.lib.capnp.Promise to capnp.lib.capnp._Promise.

### DIFF
--- a/capnp/__init__.py
+++ b/capnp/__init__.py
@@ -51,6 +51,7 @@ from .lib.capnp import (
     _StructModule,
     _write_message_to_fd,
     _write_packed_message_to_fd,
+    _Promise as Promise,
 )
 
 add_import_hook() # enable import hook by default


### PR DESCRIPTION
This is to prevent aliasing with capnp.includes.capnp_cpp.Promise. This
aliasing is problematic if capnp/lib/capnp.pxd uses the template definition
from capnp.includes.capnp_cpp.Promise.

Note: If capnp.lib.capnp._Promise is consider part of the public interface, this may break backwards compability.  However it is unclear if that is the case.