### PR TITLE
minor bug fixes for python3 + .c++ file support that is not destructive

### DIFF
--- a/capnp/_gen.py
+++ b/capnp/_gen.py
@@ -35,7 +35,7 @@ def main():
                 is_union = True
             field['c_name'] = field['name'][0].upper() + field['name'][1:]
             if 'slot' in field:
-                field['type'] = field['slot']['type'].keys()[0]
+                field['type'] = list(field['slot']['type'].keys())[0]
                 if not isinstance(field['slot']['type'][field['type']], dict):
                     continue
                 sub_type = field['slot']['type'][field['type']].get('typeId', None)

--- a/capnp/templates/setup.py.tmpl
+++ b/capnp/templates/setup.py.tmpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from distutils.core import setup
 from Cython.Build import cythonize
+from shutil import copyfile
 import os
 import re
 
@@ -10,7 +11,11 @@ files = [{% for f in code.requestedFiles %}"{{f.filename}}", {% endfor %}]
 for f in files:
   cpp_file = f + '.cpp'
   cplus_file = f + '.c++'
-  cpp_mod = os.path.getmtime(cpp_file)
+  cpp_mod = 0
+  try:
+    cpp_mod = os.path.getmtime(cpp_file)
+  except:
+    pass
   cplus_mod = 0
   try:
     cplus_mod = os.path.getmtime(cplus_file)
@@ -19,7 +24,7 @@ for f in files:
   if not os.path.exists(cpp_file) or cpp_mod < cplus_mod:
     if not os.path.exists(cplus_file):
       raise RuntimeError("You need to run `capnp compile -oc++` in addition to `-ocython` first.")
-    os.rename(cplus_file, cpp_file)
+    copyfile(cplus_file, cpp_file)
 
     with open(f + '.h', "r") as file:
         lines = file.readlines()


### PR DESCRIPTION
- fixed a bug in _gen.py where it failed for python3 as ".keys()" will return "dict_keys" object which is not indexable.
- os.path.getmtime(cpp_file) - throws an exception, so if ".cpp" file is not present it will just fail right away. Added proper check for .c++ file.
- replaced "move" with copy so command does not destroy c++ builds that depend on presence of ".c++" 