### PR TITLE
add test case for buffer release issue

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -90,8 +90,11 @@ def test_roundtrip_bytes_buffer(all_types):
 
     b = msg.to_bytes()
     v = memoryview(b)
-    msg = all_types.TestAllTypes.from_bytes(v)
-    test_regression.check_all_types(msg)
+    try:
+        msg = all_types.TestAllTypes.from_bytes(v)
+        test_regression.check_all_types(msg)
+    finally:
+        v.release()
 
 
 def test_roundtrip_bytes_fail(all_types):


### PR DESCRIPTION
This generates a new test case failure in order to reproduce 

```
FAILED test/test_serialization.py::test_roundtrip_bytes_buffer - BufferError: memoryview has 1 exported buffer
```

This PR serves mainly as additional minimal documentation for https://github.com/capnproto/pycapnp/issues/280

I will try to incorporate this test case into the new code changes involved with https://github.com/capnproto/pycapnp/pull/281