### PR TITLE
Update documentation about from_bytes to use context manager. #287

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -298,7 +298,8 @@ There is serialization to a byte string available::
 
 And a corresponding from_bytes function::
 
-    alice = addressbook_capnp.Person.from_bytes(encoded_message)
+    with addressbook_capnp.Person.from_bytes(encoded_message) as alice:
+        # something with alice
 
 There are also packed versions::
 


### PR DESCRIPTION
Update the documentation to use `with` when calling `from_bytes`, as mentioned in https://github.com/capnproto/pycapnp/issues/287.

It does not appear that `from_bytes_packed` needs this change though.  Why not?