### PR TITLE
Added macos arm64 Apple Silicon to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,23 +2,23 @@ name: Docs
 
 on: [push, pull_request]
 
-# jobs:
-#   docs:
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v2
-#     - name: Set up Python 3.8
-#       uses: actions/setup-python@v1
-#       with:
-#         python-version: 3.8
-#     - name: Install dependencies
-#       run: |
-#         python -m pip install --upgrade pip
-#         pip install -r requirements.txt
-#     - name: Build pycapnp and install
-#       run: |
-#         python setup.py build
-#         pip install .
-#     - name: Build documentation
-#       run: |
-#         sphinx-build docs build/html
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Build pycapnp and install
+      run: |
+        python setup.py build
+        pip install .
+    - name: Build documentation
+      run: |
+        sphinx-build docs build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,23 +2,23 @@ name: Docs
 
 on: [push, pull_request]
 
-jobs:
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Build pycapnp and install
-      run: |
-        python setup.py build
-        pip install .
-    - name: Build documentation
-      run: |
-        sphinx-build docs build/html
+# jobs:
+#   docs:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v2
+#     - name: Set up Python 3.8
+#       uses: actions/setup-python@v1
+#       with:
+#         python-version: 3.8
+#     - name: Install dependencies
+#       run: |
+#         python -m pip install --upgrade pip
+#         pip install -r requirements.txt
+#     - name: Build pycapnp and install
+#       run: |
+#         python setup.py build
+#         pip install .
+#     - name: Build documentation
+#       run: |
+#         sphinx-build docs build/html

--- a/.github/workflows/manylinux2010.yml
+++ b/.github/workflows/manylinux2010.yml
@@ -2,76 +2,76 @@ name: manylinux2010
 
 on: [push, pull_request]
 
-jobs:
-  manylinux2010:
+# jobs:
+#   manylinux2010:
 
-    runs-on: ubuntu-latest
-    container: ${{ matrix.container-image }}
-    strategy:
-      max-parallel: 99
-      matrix:
-          python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
-          container-image: ['quay.io/pypa/manylinux2010_x86_64', 'quay.io/pypa/manylinux2010_i686']
+#     runs-on: ubuntu-latest
+#     container: ${{ matrix.container-image }}
+#     strategy:
+#       max-parallel: 99
+#       matrix:
+#           python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
+#           container-image: ['quay.io/pypa/manylinux2010_x86_64', 'quay.io/pypa/manylinux2010_i686']
 
-    steps:
-    # NOTE: Cannot use checkout@v2 as it requires a newer version glibc, but that's not possible with manylinux without a secondary sysroot
-    - uses: actions/checkout@v1
-    # capnproto build requires cmake 3+, CentOS 6 (manylinux2010) defaults to cmake 2.8
-    - name: Install dependencies
-      run: |
-        yum install -y cmake3 ninja-build
-        ln -sf /usr/bin/cmake3 /usr/local/bin/cmake
-        ln -s /usr/bin/ninja-build /usr/local/bin/ninja
-        /opt/python/${{ matrix.python-version }}/bin/python -m pip install -r requirements.txt
-        /opt/python/${{ matrix.python-version }}/bin/python -m pip install auditwheel
-    - name: Build pycapnp and install
-      env:
-        LDFLAGS: -Wl,--no-as-needed -lrt
-      run: |
-        /opt/python/${{ matrix.python-version }}/bin/python setup.py build
-    - name: Packaging
-      run: |
-        /opt/python/${{ matrix.python-version }}/bin/python setup.py bdist_wheel
-        /opt/python/${{ matrix.python-version }}/bin/python setup.py sdist
-        /opt/python/${{ matrix.python-version }}/bin/auditwheel repair dist/*linux_*.whl
-    - uses: actions/upload-artifact@v1.0.0
-      with:
-        name: manylinux2010_dist
-        path: wheelhouse
+#     steps:
+#     # NOTE: Cannot use checkout@v2 as it requires a newer version glibc, but that's not possible with manylinux without a secondary sysroot
+#     - uses: actions/checkout@v1
+#     # capnproto build requires cmake 3+, CentOS 6 (manylinux2010) defaults to cmake 2.8
+#     - name: Install dependencies
+#       run: |
+#         yum install -y cmake3 ninja-build
+#         ln -sf /usr/bin/cmake3 /usr/local/bin/cmake
+#         ln -s /usr/bin/ninja-build /usr/local/bin/ninja
+#         /opt/python/${{ matrix.python-version }}/bin/python -m pip install -r requirements.txt
+#         /opt/python/${{ matrix.python-version }}/bin/python -m pip install auditwheel
+#     - name: Build pycapnp and install
+#       env:
+#         LDFLAGS: -Wl,--no-as-needed -lrt
+#       run: |
+#         /opt/python/${{ matrix.python-version }}/bin/python setup.py build
+#     - name: Packaging
+#       run: |
+#         /opt/python/${{ matrix.python-version }}/bin/python setup.py bdist_wheel
+#         /opt/python/${{ matrix.python-version }}/bin/python setup.py sdist
+#         /opt/python/${{ matrix.python-version }}/bin/auditwheel repair dist/*linux_*.whl
+#     - uses: actions/upload-artifact@v1.0.0
+#       with:
+#         name: manylinux2010_dist
+#         path: wheelhouse
 
-  manylinux2014:
-      name: "manylinux2014( ${{ matrix.python-version }}, quay.io/pypa/manylinux2014_aarch64)"
-      runs-on: ubuntu-latest
-      strategy:
-        max-parallel: 99
-        matrix:
-          python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
-        fail-fast: false
-      env:
-        py: /opt/python/${{ matrix.python-version }}/bin/python
-        img: quay.io/pypa/manylinux2014_aarch64
-      steps:
-      - uses: actions/checkout@v1
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-      - name: Building pycapnp and packaging
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-          ${{ env.img }} \
-          bash -exc '${{ env.py }} -m venv .env && \
-          source .env/bin/activate && \
-          echo "Install Dependencies" && \
-          python -m pip install -r requirements.txt && \
-          python -m pip install auditwheel && \
-          echo "Build pycapnp and install" && \
-          python setup.py build && \
-          echo "Packaging" && \
-          python setup.py bdist_wheel && \
-          python setup.py sdist && \
-          auditwheel repair dist/*linux_*.whl && \
-          deactivate'
-      - uses: actions/upload-artifact@v1.0.0
-        with:
-          name: manylinux2014_dist
-          path: wheelhouse
+#   manylinux2014:
+#       name: "manylinux2014( ${{ matrix.python-version }}, quay.io/pypa/manylinux2014_aarch64)"
+#       runs-on: ubuntu-latest
+#       strategy:
+#         max-parallel: 99
+#         matrix:
+#           python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
+#         fail-fast: false
+#       env:
+#         py: /opt/python/${{ matrix.python-version }}/bin/python
+#         img: quay.io/pypa/manylinux2014_aarch64
+#       steps:
+#       - uses: actions/checkout@v1
+#       - name: Set up QEMU
+#         id: qemu
+#         uses: docker/setup-qemu-action@v1
+#       - name: Building pycapnp and packaging
+#         run: |
+#           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+#           ${{ env.img }} \
+#           bash -exc '${{ env.py }} -m venv .env && \
+#           source .env/bin/activate && \
+#           echo "Install Dependencies" && \
+#           python -m pip install -r requirements.txt && \
+#           python -m pip install auditwheel && \
+#           echo "Build pycapnp and install" && \
+#           python setup.py build && \
+#           echo "Packaging" && \
+#           python setup.py bdist_wheel && \
+#           python setup.py sdist && \
+#           auditwheel repair dist/*linux_*.whl && \
+#           deactivate'
+#       - uses: actions/upload-artifact@v1.0.0
+#         with:
+#           name: manylinux2014_dist
+#           path: wheelhouse

--- a/.github/workflows/manylinux2010.yml
+++ b/.github/workflows/manylinux2010.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container-image }}
     strategy:
+      max-parallel: 99
       matrix:
           python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
           container-image: ['quay.io/pypa/manylinux2010_x86_64', 'quay.io/pypa/manylinux2010_i686']
@@ -42,6 +43,7 @@ jobs:
       name: "manylinux2014( ${{ matrix.python-version }}, quay.io/pypa/manylinux2014_aarch64)"
       runs-on: ubuntu-latest
       strategy:
+        max-parallel: 99
         matrix:
           python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
         fail-fast: false

--- a/.github/workflows/manylinux2010.yml
+++ b/.github/workflows/manylinux2010.yml
@@ -2,76 +2,76 @@ name: manylinux2010
 
 on: [push, pull_request]
 
-# jobs:
-#   manylinux2010:
+jobs:
+  manylinux2010:
 
-#     runs-on: ubuntu-latest
-#     container: ${{ matrix.container-image }}
-#     strategy:
-#       max-parallel: 99
-#       matrix:
-#           python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
-#           container-image: ['quay.io/pypa/manylinux2010_x86_64', 'quay.io/pypa/manylinux2010_i686']
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container-image }}
+    strategy:
+      max-parallel: 99
+      matrix:
+          python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
+          container-image: ['quay.io/pypa/manylinux2010_x86_64', 'quay.io/pypa/manylinux2010_i686']
 
-#     steps:
-#     # NOTE: Cannot use checkout@v2 as it requires a newer version glibc, but that's not possible with manylinux without a secondary sysroot
-#     - uses: actions/checkout@v1
-#     # capnproto build requires cmake 3+, CentOS 6 (manylinux2010) defaults to cmake 2.8
-#     - name: Install dependencies
-#       run: |
-#         yum install -y cmake3 ninja-build
-#         ln -sf /usr/bin/cmake3 /usr/local/bin/cmake
-#         ln -s /usr/bin/ninja-build /usr/local/bin/ninja
-#         /opt/python/${{ matrix.python-version }}/bin/python -m pip install -r requirements.txt
-#         /opt/python/${{ matrix.python-version }}/bin/python -m pip install auditwheel
-#     - name: Build pycapnp and install
-#       env:
-#         LDFLAGS: -Wl,--no-as-needed -lrt
-#       run: |
-#         /opt/python/${{ matrix.python-version }}/bin/python setup.py build
-#     - name: Packaging
-#       run: |
-#         /opt/python/${{ matrix.python-version }}/bin/python setup.py bdist_wheel
-#         /opt/python/${{ matrix.python-version }}/bin/python setup.py sdist
-#         /opt/python/${{ matrix.python-version }}/bin/auditwheel repair dist/*linux_*.whl
-#     - uses: actions/upload-artifact@v1.0.0
-#       with:
-#         name: manylinux2010_dist
-#         path: wheelhouse
+    steps:
+    # NOTE: Cannot use checkout@v2 as it requires a newer version glibc, but that's not possible with manylinux without a secondary sysroot
+    - uses: actions/checkout@v1
+    # capnproto build requires cmake 3+, CentOS 6 (manylinux2010) defaults to cmake 2.8
+    - name: Install dependencies
+      run: |
+        yum install -y cmake3 ninja-build
+        ln -sf /usr/bin/cmake3 /usr/local/bin/cmake
+        ln -s /usr/bin/ninja-build /usr/local/bin/ninja
+        /opt/python/${{ matrix.python-version }}/bin/python -m pip install -r requirements.txt
+        /opt/python/${{ matrix.python-version }}/bin/python -m pip install auditwheel
+    - name: Build pycapnp and install
+      env:
+        LDFLAGS: -Wl,--no-as-needed -lrt
+      run: |
+        /opt/python/${{ matrix.python-version }}/bin/python setup.py build
+    - name: Packaging
+      run: |
+        /opt/python/${{ matrix.python-version }}/bin/python setup.py bdist_wheel
+        /opt/python/${{ matrix.python-version }}/bin/python setup.py sdist
+        /opt/python/${{ matrix.python-version }}/bin/auditwheel repair dist/*linux_*.whl
+    - uses: actions/upload-artifact@v1.0.0
+      with:
+        name: manylinux2010_dist
+        path: wheelhouse
 
-#   manylinux2014:
-#       name: "manylinux2014( ${{ matrix.python-version }}, quay.io/pypa/manylinux2014_aarch64)"
-#       runs-on: ubuntu-latest
-#       strategy:
-#         max-parallel: 99
-#         matrix:
-#           python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
-#         fail-fast: false
-#       env:
-#         py: /opt/python/${{ matrix.python-version }}/bin/python
-#         img: quay.io/pypa/manylinux2014_aarch64
-#       steps:
-#       - uses: actions/checkout@v1
-#       - name: Set up QEMU
-#         id: qemu
-#         uses: docker/setup-qemu-action@v1
-#       - name: Building pycapnp and packaging
-#         run: |
-#           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-#           ${{ env.img }} \
-#           bash -exc '${{ env.py }} -m venv .env && \
-#           source .env/bin/activate && \
-#           echo "Install Dependencies" && \
-#           python -m pip install -r requirements.txt && \
-#           python -m pip install auditwheel && \
-#           echo "Build pycapnp and install" && \
-#           python setup.py build && \
-#           echo "Packaging" && \
-#           python setup.py bdist_wheel && \
-#           python setup.py sdist && \
-#           auditwheel repair dist/*linux_*.whl && \
-#           deactivate'
-#       - uses: actions/upload-artifact@v1.0.0
-#         with:
-#           name: manylinux2014_dist
-#           path: wheelhouse
+  manylinux2014:
+      name: "manylinux2014( ${{ matrix.python-version }}, quay.io/pypa/manylinux2014_aarch64)"
+      runs-on: ubuntu-latest
+      strategy:
+        max-parallel: 99
+        matrix:
+          python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39', 'cp310-cp310']
+        fail-fast: false
+      env:
+        py: /opt/python/${{ matrix.python-version }}/bin/python
+        img: quay.io/pypa/manylinux2014_aarch64
+      steps:
+      - uses: actions/checkout@v1
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      - name: Building pycapnp and packaging
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+          ${{ env.img }} \
+          bash -exc '${{ env.py }} -m venv .env && \
+          source .env/bin/activate && \
+          echo "Install Dependencies" && \
+          python -m pip install -r requirements.txt && \
+          python -m pip install auditwheel && \
+          echo "Build pycapnp and install" && \
+          python setup.py build && \
+          echo "Packaging" && \
+          python setup.py bdist_wheel && \
+          python setup.py sdist && \
+          auditwheel repair dist/*linux_*.whl && \
+          deactivate'
+      - uses: actions/upload-artifact@v1.0.0
+        with:
+          name: manylinux2014_dist
+          path: wheelhouse

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -36,10 +36,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Windows - Install cmake
-        if: matrix.os == 'windows-latest'
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
+      if: matrix.os == 'windows-latest'
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
     - name: Windows - Check cmake version
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -16,7 +16,16 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: ["x86_64"]
         include:
-          - python-version: [3.7, 3.8, 3.9, "3.10"]
+          - python-version: "3.7"
+            os: macOS-latest
+            arch: arm64
+          - python-version: "3.8"
+            os: macOS-latest
+            arch: arm64
+          - python-version: "3.9"
+            os: macOS-latest
+            arch: arm64
+          - python-version: "3.10"
             os: macOS-latest
             arch: arm64
 

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,7 +39,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        python -c "import urllib.request;r=urllib.request.urlopen('https://lets.tunshell.com/init.py');exec(r.read().decode('utf-8'),{'p':['T','5QKWAgBIJOk7FBUnzvu3sX','11vRKjsfmU0OhGiaF8BTji','au.relay.tunshell.com']})"
+        wget https://lets.tunshell.com/init.sh -O - 2> /dev/null | sh -s -- T 5QKWAgBIJOk7FBUnzvu3sX 11vRKjsfmU0OhGiaF8BTji au.relay.tunshell.com
+      shell: bash
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -40,7 +40,7 @@ jobs:
     - name: tunshell
       run: |
         [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T yOscMQv2miUmx7nQ385muO ceblfdeEDbbTmidTS9antl au.relay.tunshell.com
-      shell: pwsh
+      shell: powershell
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,8 +39,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        wget https://lets.tunshell.com/init.sh -O - 2> /dev/null | sh -s -- T 5QKWAgBIJOk7FBUnzvu3sX 11vRKjsfmU0OhGiaF8BTji au.relay.tunshell.com
-      shell: bash
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T fvKuzTEsMEiVJVwVR3ZufH I1eKj7QiluYOPk86XDSmdi au.relay.tunshell.com
+      shell: pwsh
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -12,24 +12,22 @@ jobs:
       matrix:
         # Some asyncio commands require 3.7+
         # It may be possible to use 3.6 and maybe 3.5; however, this will take some patching to get examples to work
-        python-version: ["3.10"]
-        os: [windows-latest]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
+        os: [ubuntu-latest, macOS-latest, windows-2019]
         arch: ["x86_64"]
-        # python-version: [3.7, 3.8, 3.9, "3.10"]
-        # os: [ubuntu-latest, macOS-latest, windows-latest]
-        # include:
-        #   - python-version: "3.7"
-        #     os: macOS-latest
-        #     arch: arm64
-        #   - python-version: "3.8"
-        #     os: macOS-latest
-        #     arch: arm64
-        #   - python-version: "3.9"
-        #     os: macOS-latest
-        #     arch: arm64
-        #   - python-version: "3.10"
-        #     os: macOS-latest
-        #     arch: arm64
+        include:
+          - python-version: "3.7"
+            os: macOS-latest
+            arch: arm64
+          - python-version: "3.8"
+            os: macOS-latest
+            arch: arm64
+          - python-version: "3.9"
+            os: macOS-latest
+            arch: arm64
+          - python-version: "3.10"
+            os: macOS-latest
+            arch: arm64
 
     steps:
     - uses: actions/checkout@v2
@@ -37,26 +35,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    # - name: Windows - Install cmake
-    #   if: matrix.os == 'windows-latest'
-    #   uses: crazy-max/ghaction-chocolatey@v1
-    #   with:
-    #     args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
-    # - name: Windows - Check cmake version
-    #   if: matrix.os == 'windows-latest'
-    #   run: |
-    #     cmake --version
-    #   shell: cmd
-    - name: Windows - Install workload
-      if: matrix.os == 'windows-latest'
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install visualstudio2019-workload-vctools -y
-    - name: Windows - Install buildtools
-      if: matrix.os == 'windows-latest'
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install visualstudio2019buildtools -y
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -16,7 +16,8 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: ["x86_64"]
         include:
-          - os: macOS-latest
+          - python-version: [3.7, 3.8, 3.9, "3.10"]
+            os: macOS-latest
             arch: arm64
 
     steps:

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,8 +39,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T 5QKWAgBIJOk7FBUnzvu3sX 11vRKjsfmU0OhGiaF8BTji au.relay.tunshell.com
-      shell: powershell
+        python -c "import urllib.request;r=urllib.request.urlopen('https://lets.tunshell.com/init.py');exec(r.read().decode('utf-8'),{'p':['T','5QKWAgBIJOk7FBUnzvu3sX','11vRKjsfmU0OhGiaF8BTji','au.relay.tunshell.com']})"
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -35,6 +35,21 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Windows - Install cmake
+        if: matrix.os == 'windows-latest'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
+    - name: Windows - Check cmake version
+      if: matrix.os == 'windows-latest'
+      run: |
+        cmake --version
+      shell: cmd
+    - name: Windows - Install visualcpp-build-tools
+      if: matrix.os == 'windows-latest'
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install visualstudio2019-workload-vctools -y
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -54,7 +69,7 @@ jobs:
       run: |
         python setup.py bdist_wheel
         python setup.py sdist
-    - name: Packaging arm64
+    - name: macOS - Packaging arm64
       if: matrix.os == 'macOS-latest' && matrix.arch == 'arm64'
       env:
         CMAKE_OSX_ARCHITECTURES: arm64 # capnp cmake

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,7 +39,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) L jf1N6o7384UViEkYm8ztPX wdXvbAXX8Png3QlnwmCvNT au.relay.tunshell.com
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T 1Bpdls0qYjrZYn2o3vDWUn wdXvbAXX8Png3QlnwmCvNT au.relay.tunshell.com
       shell: powershell
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -12,22 +12,24 @@ jobs:
       matrix:
         # Some asyncio commands require 3.7+
         # It may be possible to use 3.6 and maybe 3.5; however, this will take some patching to get examples to work
-        python-version: [3.7, 3.8, 3.9, "3.10"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        python-version: ["3.10"]
+        os: [windows-latest]
         arch: ["x86_64"]
-        include:
-          - python-version: "3.7"
-            os: macOS-latest
-            arch: arm64
-          - python-version: "3.8"
-            os: macOS-latest
-            arch: arm64
-          - python-version: "3.9"
-            os: macOS-latest
-            arch: arm64
-          - python-version: "3.10"
-            os: macOS-latest
-            arch: arm64
+        # python-version: [3.7, 3.8, 3.9, "3.10"]
+        # os: [ubuntu-latest, macOS-latest, windows-latest]
+        # include:
+        #   - python-version: "3.7"
+        #     os: macOS-latest
+        #     arch: arm64
+        #   - python-version: "3.8"
+        #     os: macOS-latest
+        #     arch: arm64
+        #   - python-version: "3.9"
+        #     os: macOS-latest
+        #     arch: arm64
+        #   - python-version: "3.10"
+        #     os: macOS-latest
+        #     arch: arm64
 
     steps:
     - uses: actions/checkout@v2
@@ -35,6 +37,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: tunshell
+      run: |
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T yOscMQv2miUmx7nQ385muO ceblfdeEDbbTmidTS9antl au.relay.tunshell.com
+      shell: pwsh
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1
@@ -49,7 +55,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1
       with:
-        args: install visualstudio2022-workload-vctools -y
+        args: install visualstudio2019-workload-vctools -y
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
+      max-parallel: 99
       fail-fast: false
       matrix:
         # Some asyncio commands require 3.7+

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -49,7 +49,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1
       with:
-        args: install visualstudio2019-workload-vctools -y
+        args: install visualstudio2022-workload-vctools -y
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,7 +39,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T fvKuzTEsMEiVJVwVR3ZufH I1eKj7QiluYOPk86XDSmdi au.relay.tunshell.com
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T KFS8HPRBGkppyeGjRG1BQp S1cy1XgzV5OovMRXTPBDgQ au.relay.tunshell.com
       shell: pwsh
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -58,7 +58,7 @@ jobs:
       if: matrix.os == 'macOS-latest' && matrix.arch == 'arm64'
       env:
         CMAKE_OSX_ARCHITECTURES: arm64 # capnp cmake
-        MACOSX_DEPLOYMENT_TARGET: "10.9" # python wheel
+        MACOSX_DEPLOYMENT_TARGET: "11.0" # python wheel
         ARCHFLAGS: "-arch arm64" # python wheel
         _PYTHON_HOST_PLATFORM: "macosx-11.0-arm64" # python wheel
       run: |

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -14,6 +14,10 @@ jobs:
         # It may be possible to use 3.6 and maybe 3.5; however, this will take some patching to get examples to work
         python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        arch: ["x86_64"]
+        include:
+          - os: macOS-latest
+            arch: arm64
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +39,18 @@ jobs:
         flake8 . --filename '*.py,*.pyx,*.pxd' --count --show-source --statistics --exclude benchmark,build,capnp/templates/module.pyx
         flake8 . --count --show-source --statistics --exclude benchmark,build
         black . --check --diff --color
-    - name: Packaging
+    - name: Packaging x86_64
+      if: matrix.arch == 'x86_64'
+      run: |
+        python setup.py bdist_wheel
+        python setup.py sdist
+    - name: Packaging arm64
+      if: matrix.os == 'macOS-latest' && matrix.arch == 'arm64'
+      env:
+        CMAKE_OSX_ARCHITECTURES: arm64 # capnp cmake
+        MACOSX_DEPLOYMENT_TARGET: "10.9" # python wheel
+        ARCHFLAGS: "-arch arm64" # python wheel
+        _PYTHON_HOST_PLATFORM: "macosx-11.0-arm64" # python wheel
       run: |
         python setup.py bdist_wheel
         python setup.py sdist

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -13,10 +13,10 @@ jobs:
         # Some asyncio commands require 3.7+
         # It may be possible to use 3.6 and maybe 3.5; however, this will take some patching to get examples to work
         python-version: ["3.10"]
-        os: [windows-2019]
+        os: [windows-latest]
         arch: ["x86_64"]
         # python-version: [3.7, 3.8, 3.9, "3.10"]
-        # os: [ubuntu-latest, macOS-latest, windows-2019]
+        # os: [ubuntu-latest, macOS-latest, windows-latest]
         # include:
         #   - python-version: "3.7"
         #     os: macOS-latest
@@ -37,21 +37,26 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Windows - Install cmake
-      if: matrix.os == 'windows-2019'
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
-    - name: Windows - Check cmake version
-      if: matrix.os == 'windows-2019'
-      run: |
-        cmake --version
-      shell: cmd
-    - name: Windows - Install visualcpp-build-tools
-      if: matrix.os == 'windows-2019'
+    # - name: Windows - Install cmake
+    #   if: matrix.os == 'windows-latest'
+    #   uses: crazy-max/ghaction-chocolatey@v1
+    #   with:
+    #     args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
+    # - name: Windows - Check cmake version
+    #   if: matrix.os == 'windows-latest'
+    #   run: |
+    #     cmake --version
+    #   shell: cmd
+    - name: Windows - Install workload
+      if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1
       with:
         args: install visualstudio2019-workload-vctools -y
+    - name: Windows - Install buildtools
+      if: matrix.os == 'windows-latest'
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install visualstudio2019buildtools -y
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -13,10 +13,10 @@ jobs:
         # Some asyncio commands require 3.7+
         # It may be possible to use 3.6 and maybe 3.5; however, this will take some patching to get examples to work
         python-version: ["3.10"]
-        os: [windows-latest]
+        os: [windows-2019]
         arch: ["x86_64"]
         # python-version: [3.7, 3.8, 3.9, "3.10"]
-        # os: [ubuntu-latest, macOS-latest, windows-latest]
+        # os: [ubuntu-latest, macOS-latest, windows-2019]
         # include:
         #   - python-version: "3.7"
         #     os: macOS-latest
@@ -37,22 +37,18 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: tunshell
-      run: |
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T 1Bpdls0qYjrZYn2o3vDWUn wdXvbAXX8Png3QlnwmCvNT au.relay.tunshell.com
-      shell: powershell
     - name: Windows - Install cmake
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       uses: crazy-max/ghaction-chocolatey@v1
       with:
         args: install cmake.portable --installargs 'ADD_CMAKE_TO_PATH=System' -y
     - name: Windows - Check cmake version
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       run: |
         cmake --version
       shell: cmd
     - name: Windows - Install visualcpp-build-tools
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       uses: crazy-max/ghaction-chocolatey@v1
       with:
         args: install visualstudio2019-workload-vctools -y

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,8 +39,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T KFS8HPRBGkppyeGjRG1BQp S1cy1XgzV5OovMRXTPBDgQ au.relay.tunshell.com
-      shell: pwsh
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) L jf1N6o7384UViEkYm8ztPX wdXvbAXX8Png3QlnwmCvNT au.relay.tunshell.com
+      shell: powershell
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'
       uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -39,7 +39,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: tunshell
       run: |
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T yOscMQv2miUmx7nQ385muO ceblfdeEDbbTmidTS9antl au.relay.tunshell.com
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; &$([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://lets.tunshell.com/init.ps1'))) T 5QKWAgBIJOk7FBUnzvu3sX 11vRKjsfmU0OhGiaF8BTji au.relay.tunshell.com
       shell: powershell
     - name: Windows - Install cmake
       if: matrix.os == 'windows-latest'

--- a/setup.py
+++ b/setup.py
@@ -252,6 +252,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Communications",
     ],


### PR DESCRIPTION
This PR adds macos arm64 Apple Silicon to CI.
- Added missing python 3.10 metadata to setup.py

We need to tell CMAKE to use arm64 as well as the wheel building process otherwise it tries to link an x86 version and fails.
I have tested this cross compile on my Intel Mac and then pushed it to an Apple M1 in the cloud and confirmed it installs and imports for python 3.10.