### PR TITLE
Fixing issue with m1 build

### DIFF
--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -73,6 +73,7 @@ jobs:
         name: package_dist
         path: dist
     - name: Test with pytest
+      if: matrix.arch == 'x86_64'
       run: |
         pip install pytest
         pytest

--- a/.github/workflows/packagingtest.yml
+++ b/.github/workflows/packagingtest.yml
@@ -40,6 +40,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Build pycapnp and install
+      if: matrix.arch == 'x86_64'
       run: |
         python setup.py build
         pip install .
@@ -62,7 +63,10 @@ jobs:
         ARCHFLAGS: "-arch arm64" # python wheel
         _PYTHON_HOST_PLATFORM: "macosx-11.0-arm64" # python wheel
       run: |
-        python setup.py bdist_wheel
+        env
+        rm -rf dist build build64 bundled
+        python setup.py bdist_wheel --force-bundled-libcapnp
+        ls -lh dist
         python setup.py sdist
     - uses: actions/upload-artifact@v1.0.0
       with:


### PR DESCRIPTION
Unfortunately one of our users reported the wheel doesn't work on Apple Silicon.
We have verified and those wheels are too small. There is about 3mb of .so file missing.

The error is:
```
ImportError: dlopen(/Users/rasswanth/.local/share/virtualenvs/python310-SoWwEFAM/lib/python3.10/site-packages/capnp/lib/capnp.cpython-310-darwin.so, 0x0002): symbol not found in flat namespace '__ZN2kj1_11ForkHubBase16getInnerForTraceEv'
```

I am fairly sure that its because the capnp lib gets built for a different arch and then it just skips linking it.
You can see in the logs:
```
ld: warning: directory not found for option '-L/Users/runner/work/pycapnp/pycapnp/build64/lib64'
ld: warning: ignoring file /Users/runner/work/pycapnp/pycapnp/build64/lib/libcapnpc.a, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
ld: warning: ignoring file /Users/runner/work/pycapnp/pycapnp/build64/lib/libcapnp-rpc.a, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
ld: warning: ignoring file /Users/runner/work/pycapnp/pycapnp/build64/lib/libcapnp.a, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
ld: warning: ignoring file /Users/runner/work/pycapnp/pycapnp/build64/lib/libkj-async.a, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
ld: warning: ignoring file /Users/runner/work/pycapnp/pycapnp/build64/lib/libkj.a, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
```

I guess I was careful to clean and only build locally when testing and pushing my hand rolled wheel to a cloud M1 instance.

I have added some steps to hopefully fix it and to make it easy to verify by eye balling the wheel size as well.

- prevent earlier build step from running on arm64
- forced clean up of bundled dir
- adding --force-bundled-libcapnp to trigger a rebuild
- echoing out env variables and showing final wheel size