### PR TITLE
Bundle lib/capnp_api.h and helpers/capabilityHelper.cpp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,10 +218,12 @@ setup(
             "*.capnp",
             "helpers/*.pxd",
             "helpers/*.h",
+            "helpers/*.cpp",
             "includes/*.pxd",
             "lib/*.pxd",
             "lib/*.py",
             "lib/*.pyx",
+            "lib/*.h",
             "templates/*",
         ]
     },


### PR DESCRIPTION
I'm statically linking against some of the Cython files of Pycapnp. These two files are missing from `package_data`. It's a bit awkward to bundle `capabilityHelper.cpp` and to link to it, but without an import like this fails at runtime.
```
from capnp.helpers.non_circular cimport reraise_kj_exception
```