### PR TITLE
Pin cython to below version 3, Python 3.11 support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [packages]
-Cython = "*"
+Cython = "<3"
 Jinja2 = "*"
 black = "*"
 flake8 = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pkgconfig", "cython"]
+requires = ["setuptools", "wheel", "pkgconfig", "cython<3"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jinja2
 black
-cython
+cython<3
 flake8
 setuptools
 pkgconfig

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps=
     pkgconfig
     Jinja2
     pytest
-    cython
+    cython<3
 
 commands =
     python setup.py install


### PR DESCRIPTION
Cython 3 includes backwards incompatible changes so it's no longer possible to install pycapnp from source.

I'm not sure if that tox file change is enough to start running CI for 3.11, but I'm much less worried about that part than the broken builds.

Fixes #319 