### PR TITLE
Add custom build backend to support build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,25 +38,27 @@ cd pycapnp
 pip install .
 ```
 
+By default, the setup script will automatically use the locally installed Cap'n Proto.
+If Cap'n Proto is not installed, it will bundle and build the matching Cap'n Proto library.
+
+To enforce bundling, the Cap'n Proto library:
+
+```bash
+pip install . -C force-bundled-libcapnp=True
+```
+
 If you wish to install using the latest upstream C++ Cap'n Proto:
 
 ```bash
-pip install \
-    --install-option "--libcapnp-url" \
-    --install-option "https://github.com/capnproto/capnproto/archive/master.tar.gz" \
-    --install-option "--force-bundled-libcapnp" .
+pip install . \
+    -C force-bundled-libcapnp=True \
+    -C libcapnp-url="https://github.com/capnproto/capnproto/archive/master.tar.gz"
 ```
 
-To force bundled python:
+To enforce using the installed Cap'n Proto from the system:
 
 ```bash
-pip install --install-option "--force-bundled-libcapnp" .
-```
-
-Slightly more prompt error messages using distutils rather than pip.
-
-```bash
-python setup.py install --force-bundled-libcapnp
+pip install . -C force-system-libcapnp=True
 ```
 
 The bundling system isn't that smart so it might be necessary to clean up the bundled build when changing versions:
@@ -92,18 +94,11 @@ pipenv run pytest
 
 ### Binary Packages
 
-Building a dumb binary distribution:
+Building a Python wheel distributiion
 
 ```bash
-python setup.py bdist_dumb
+pip wheel .
 ```
-
-Building a Python wheel distributiion:
-
-```bash
-python setup.py bdist_wheel
-```
-
 
 ## Documentation/Example
 

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,31 @@
+import sys
+
+from setuptools.build_meta import *  # noqa: F401, F403
+from setuptools.build_meta import build_wheel
+
+backend_class = build_wheel.__self__.__class__
+
+
+class _CustomBuildMetaBackend(backend_class):
+    def run_setup(self, setup_script="setup.py"):
+        if self.config_settings:
+            flags = []
+            if self.config_settings.get("force-bundled-libcapnp"):
+                flags.append("--force-bundled-libcapnp")
+            if self.config_settings.get("force-system-libcapnp"):
+                flags.append("--force-system-libcapnp")
+            if self.config_settings.get("libcapnp-url"):
+                flags.append("--libcapnp-url")
+                flags.append(self.config_settings["libcapnp-url"])
+            if flags:
+                sys.argv = sys.argv[:1] + ["build_ext"] + flags + sys.argv[1:]
+        return super().run_setup(setup_script)
+
+    def build_wheel(
+        self, wheel_directory, config_settings=None, metadata_directory=None
+    ):
+        self.config_settings = config_settings
+        return super().build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+build_wheel = _CustomBuildMetaBackend().build_wheel

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,8 +15,8 @@ To force rebuilding the pip package from source (you'll need requirments.txt or 
 
 To force bundling libcapnp (or force system libcapnp), just in case setup.py isn't doing the right thing::
 
-    pip install --no-binary :all: --install-option "--force-bundled-libcapnp"
-    pip install --no-binary :all: --install-option "--force-system-libcapnp"
+    pip install --no-binary :all: -C force-bundled-libcapnp=True
+    pip install --no-binary :all: -C force-system-libcapnp=True
 
 If you're using an older Linux distro (e.g. CentOS 6) you many need to set `LDFLAGS="-Wl,--no-as-needed -lrt"`::
 
@@ -24,7 +24,7 @@ If you're using an older Linux distro (e.g. CentOS 6) you many need to set `LDFL
 
 It's also possible to specify the libcapnp url when bundling (this may not work, there be dragons)::
 
-    pip install --no-binary :all: --install-option "--force-bundled-libcapnp" --install-option "--libcapnp-url" --install-option "https://github.com/capnproto/capnproto/archive/master.tar.gz"
+    pip install --no-binary :all: -C force-bundled-libcapnp=True -C libcapnp-url="https://github.com/capnproto/capnproto/archive/master.tar.gz"
 
 From Source
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
 requires = ["setuptools", "wheel", "pkgconfig", "cython<3"]
+build-backend = "backend"
+backend-path = ["_custom_build"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 license_files = LICENSE.md

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,11 @@ deps=
     pkgconfig
     Jinja2
     pytest
+    pytest-asyncio
     cython<3
 
 commands =
-    python setup.py install
+    pip install .
     py.test {posargs}
 
 setenv =


### PR DESCRIPTION
This implements a custom build backend, inspired by the [solution used by Pillow.](https://github.com/python-pillow/Pillow/pull/7171)

install-option is deprecated and was removed with pip 23.1. The comonly accepted solution seems to be to define a custom build backend for now
https://github.com/pypa/setuptools/issues/2491#issuecomment-1589764230

This commit changes the usage from `--install-option` to `--config-settings`.