### PR TITLE
[WIP] Python 3.12 Support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.12"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.12.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.12.0
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Communications",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py37,py38,py39,py310,py311,py312
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
I am having some issues building for python 3.12 locally on MacOS.

```
^~~~~~~~~
capnp/lib/capnp.cpp:45585:28: error: no member named 'allowCancellation' in 'capnp::CallContext<capnp::DynamicStruct, capnp::DynamicStruct>'
    __pyx_v_self->thisptr->allowCancellation();
```

I saw that `allowCancellation` was mentioned in the breaking 1.0 release notes but I think `pycapnp` is still using an older version of capnp right?

Also, do we want to change `bundled_version` to `(1, 0, 1)`?

I haven't had time to debug whats going on, but I also don't know how the python version releases are done as I don't see any version information in `wheels.yml`. Does it just depend on what cibuildwheel version?

https://cibuildwheel.readthedocs.io/en/stable/
```
⁵ CPython 3.12 is built by default using Python RCs, starting with cibuildwheel 2.15.
```