### PR TITLE
Unlock the GIL for all capnp functions that do IO

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -3718,7 +3718,9 @@ cdef class _StreamFdMessageReader(_MessageReader):
         cdef schema_cpp.ReaderOptions opts = make_reader_opts(traversal_limit_in_words, nesting_limit)
 
         self._parent = file
-        self.thisptr = new schema_cpp.StreamFdMessageReader(file.fileno(), opts)
+        cdef int fd = file.fileno()
+        with nogil:
+            self.thisptr = new schema_cpp.StreamFdMessageReader(fd, opts)
 
     def __dealloc__(self):
         del self.thisptr
@@ -3821,7 +3823,9 @@ cdef class _PackedFdMessageReader(_MessageReader):
         cdef schema_cpp.ReaderOptions opts = make_reader_opts(traversal_limit_in_words, nesting_limit)
 
         self._parent = file
-        self.thisptr = new schema_cpp.PackedFdMessageReader(file.fileno(), opts)
+        cdef int fd = file.fileno()
+        with nogil:
+            self.thisptr = new schema_cpp.PackedFdMessageReader(fd, opts)
 
     def __dealloc__(self):
         del self.thisptr
@@ -4230,7 +4234,8 @@ def _write_message_to_fd(int fd, _MessageBuilder message):
 
     :rtype: void
     """
-    schema_cpp.writeMessageToFd(fd, deref(message.thisptr))
+    with nogil:
+        schema_cpp.writeMessageToFd(fd, deref(message.thisptr))
 
 
 def _write_packed_message_to_fd(int fd, _MessageBuilder message):
@@ -4257,7 +4262,8 @@ def _write_packed_message_to_fd(int fd, _MessageBuilder message):
 
     :rtype: void
     """
-    schema_cpp.writePackedMessageToFd(fd, deref(message.thisptr))
+    with nogil:
+        schema_cpp.writePackedMessageToFd(fd, deref(message.thisptr))
 
 
 _global_schema_parser = None


### PR DESCRIPTION
IO might block, and its rude to block while holding the GIL, since that prevents other threads from running.