### PR TITLE
DynamicCapabilityClient: fix crash due to wrong types

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -2199,7 +2199,7 @@ cdef class _DynamicCapabilityClient:
             return self._cached_schema
 
     def __dir__(self):
-        return list(set(self.schema.method_names_inherited) + tuple(dir(self.__class__)))
+        return list(set(self.schema.method_names_inherited + tuple(dir(self.__class__))))
 
 
 cdef class _CapabilityClient:


### PR DESCRIPTION
In the last commit touching this line, a ')' was put in the wrong place, leading to errors like this one:

```
  File "capnp/lib/capnp.pyx", line 2172, in capnp.lib.capnp._DynamicCapabilityClient.__dir__
TypeError: unsupported operand type(s) for +: 'set' and 'tuple'
```