### PR TITLE
Disable the use of ninja for windows builds

### DIFF
--- a/buildutils/build.py
+++ b/buildutils/build.py
@@ -28,7 +28,7 @@ def build_libcapnp(bundle_dir, build_dir):  # noqa: C901
 
     # Enable ninja for compilation if available
     build_type = []
-    if shutil.which("ninja"):
+    if shutil.which("ninja") and os.name != "nt":
         build_type = ["-G", "Ninja"]
 
     # Determine python shell architecture for Windows


### PR DESCRIPTION
Apparently github added ninja to all of there runners now. This causes the windows build to fail. This is expected because we add the architecture as a compiler arg unknown to ninja. Even with this, the build fails.

This commit disables ninja on windows for now. Once we fix the underlying issue with ninja and windows we can reenable it.

@haata I am currently investigating how we could use ninja for windows as well ... but in the meantime, I think its best to disable it explicitly. Not sure if we even want that?

