### PR TITLE
Make `reraise_kj_exception` available to downstream

### DIFF
--- a/capnp/helpers/capabilityHelper.cpp
+++ b/capnp/helpers/capabilityHelper.cpp
@@ -6,7 +6,7 @@
       return stealPyRef(wrap_dynamic_struct_reader(response)); } );
 }
 
-void reraise_kj_exception() {
+void c_reraise_kj_exception() {
   GILAcquire gil;
   try {
     if (PyErr_Occurred())

--- a/capnp/helpers/capabilityHelper.h
+++ b/capnp/helpers/capabilityHelper.h
@@ -63,7 +63,7 @@ inline ::kj::Promise<kj::Own<PyRefCounter>> convert_to_pypromise(kj::Promise<voi
     });
 }
 
-void reraise_kj_exception();
+void c_reraise_kj_exception();
 
 void check_py_error();
 

--- a/capnp/helpers/helpers.pxd
+++ b/capnp/helpers/helpers.pxd
@@ -6,7 +6,7 @@ from capnp.includes.capnp_cpp cimport (
 
 from capnp.includes.schema_cpp cimport ByteArray
 
-from non_circular cimport reraise_kj_exception
+from non_circular cimport c_reraise_kj_exception as reraise_kj_exception
 
 from cpython.ref cimport PyObject
 

--- a/capnp/helpers/non_circular.pxd
+++ b/capnp/helpers/non_circular.pxd
@@ -2,7 +2,7 @@ from cpython.ref cimport PyObject
 from libcpp cimport bool
 
 cdef extern from "capnp/helpers/capabilityHelper.h":
-    void reraise_kj_exception()
+    void c_reraise_kj_exception()
     cdef cppclass PyRefCounter:
         PyRefCounter(PyObject *)
         PyObject * obj

--- a/capnp/includes/capnp_cpp.pxd
+++ b/capnp/includes/capnp_cpp.pxd
@@ -5,7 +5,7 @@ cdef extern from "capnp/helpers/checkCompiler.h":
 
 from libcpp cimport bool
 from capnp.helpers.non_circular cimport (
-    reraise_kj_exception, PyRefCounter,
+    c_reraise_kj_exception as reraise_kj_exception, PyRefCounter,
 )
 from capnp.includes.schema_cpp cimport (
     Node, Data, StructNode, EnumNode, InterfaceNode, MessageBuilder, MessageReader, ReaderOptions,

--- a/capnp/includes/schema_cpp.pxd
+++ b/capnp/includes/schema_cpp.pxd
@@ -2,7 +2,7 @@
 # distutils: language = c++
 
 from libc.stdint cimport *
-from capnp.helpers.non_circular cimport reraise_kj_exception
+from capnp.helpers.non_circular cimport c_reraise_kj_exception as reraise_kj_exception
 
 from capnp.includes.types cimport *
 

--- a/capnp/lib/capnp.pxd
+++ b/capnp/lib/capnp.pxd
@@ -15,9 +15,9 @@ from capnp.includes.capnp_cpp cimport (
 )
 from capnp.includes.schema_cpp cimport Node as C_Node, EnumNode as C_EnumNode
 from capnp.includes.types cimport *
-from capnp.helpers.non_circular cimport reraise_kj_exception
 from capnp.helpers cimport helpers
 
+cdef void reraise_kj_exception()
 
 cdef class _StructSchemaField:
     cdef C_StructSchema.Field thisptr

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -281,6 +281,10 @@ cdef api object wrap_kj_exception_for_reraise(capnp.Exception & exception) with 
     return ret
 
 
+cdef void reraise_kj_exception():
+    helpers.reraise_kj_exception()
+
+
 cdef api object get_exception_info(object exc_type, object exc_obj, object exc_tb) with gil:
     try:
         return (exc_tb.tb_frame.f_code.co_filename.encode(),

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,6 @@ setup(
             "*.capnp",
             "helpers/*.pxd",
             "helpers/*.h",
-            "helpers/*.cpp",
             "includes/*.pxd",
             "lib/*.pxd",
             "lib/*.py",


### PR DESCRIPTION
I'm using Pycapnp in a project, where we compile `.capnp` files directly to Cython instead of using the dynamic interface (for speed). For this, we need access to the `reraise_kj_exception` C function defined by Pycapnp. This is not possible, because Cython does not automatically make this function available to downstream users.

My previous solution, in #301, was rather flawed. The  file `capabilityHelper.cpp`, where `reraise_kj_exception` is defined, was bundled into the distribution, so that this file could be included in downstream libraries. This turns out to be a terrible idea, because it redefines a bunch of other things like `ReadPromiseAdapter`. For reasons not entirely clear to me, this leads to segmentation faults. This PR revers #301.

Instead, in this PR I've made `reraise_kj_exception` a Cython-level function, that can be used by downstream libraries. The C-level variant has been renamed to `c_reraise_kj_exception`.