### PR TITLE
Properly join list of methods in _DynamicCapabilityClient

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -2199,7 +2199,7 @@ cdef class _DynamicCapabilityClient:
             return self._cached_schema
 
     def __dir__(self):
-        return list(set(self.schema.method_names_inherited + tuple(dir(self.__class__))))
+        return list(set(self.schema.method_names_inherited) | set(dir(self.__class__)))
 
 
 cdef class _CapabilityClient:

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -51,6 +51,13 @@ async def test_simple_rpc_bootstrap():
     cap = client.bootstrap()
     cap = cap.cast_as(test_capability_capnp.TestInterface)
 
+    # Check not only that the methods are there, but also that they are listed
+    # as expected.
+    assert "foo" in dir(cap)
+    assert "bar" in dir(cap)
+    assert "buz" in dir(cap)
+    assert "bam" in dir(cap)
+
     remote = cap.foo(i=5)
     response = await remote
 


### PR DESCRIPTION
This was already fixed in c9bea05f44, but the fix does not seem to work. This commit uses a set union, which should be more robust. It also adds a couple of assertions to verify that it indeed works.