### PR TITLE
Fix re-raising of KjException

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -260,9 +260,9 @@ class KjException(Exception):
 
     def _to_python(self):
         message = self.message
-        if self.wrapper.type == 'FAILED':
+        if self.wrapper is not None and self.wrapper.type == 'FAILED':
             if 'has no such' in self.message:
-                return AttributeError(message)
+                return AttributeError(message).with_traceback(self.__traceback__)
         return self
 
 
@@ -1125,7 +1125,7 @@ cdef class _DynamicStructReader:
         try:
             return self._get(field)
         except KjException as e:
-            raise e._to_python(), None, _sys.exc_info()[2]
+            raise e._to_python() from None
 
     cpdef _get_by_field(self, _StructSchemaField field):
         return to_python_reader(self.thisptr.getByField(field.thisptr), self)
@@ -1372,7 +1372,7 @@ cdef class _DynamicStructBuilder:
         try:
             return self._get(field)
         except KjException as e:
-            raise e._to_python(), None, _sys.exc_info()[2]
+            raise e._to_python() from None
 
     cpdef _set(self, field, value):
         _setDynamicField(self.thisptr, field, value, self._parent)
@@ -1384,7 +1384,7 @@ cdef class _DynamicStructBuilder:
         try:
             self._set(field, value)
         except KjException as e:
-            raise e._to_python(), None, _sys.exc_info()[2]
+            raise e._to_python() from None
 
     cpdef _has(self, field):
         return self.thisptr.has(field)
@@ -1636,7 +1636,7 @@ cdef class _DynamicStructPipeline:
         try:
             return self._get(field)
         except KjException as e:
-            raise e._to_python(), None, _sys.exc_info()[2]
+            raise e._to_python() from None
 
     property schema:
         """A property that returns the _StructSchema object matching this reader"""
@@ -2022,7 +2022,7 @@ cdef class _RemotePromise:
         try:
             return self._get(field)
         except KjException as e:
-            raise e._to_python(), None, _sys.exc_info()[2]
+            raise e._to_python() from None
 
     property schema:
         """A property that returns the _StructSchema object matching this reader"""
@@ -2176,7 +2176,7 @@ cdef class _DynamicCapabilityClient:
                 raise AttributeError('Method named %s not found' % name)
             return _partial(self._send, name)
         except KjException as e:
-            raise e._to_python(), None, _sys.exc_info()[2]
+            raise e._to_python() from None
 
     cpdef upcast(self, schema) except +reraise_kj_exception:
         cdef _InterfaceSchema s


### PR DESCRIPTION
- The `KjException._to_python()` function neglected to check if the wrapper was set when attempting to convert to `AttributeError`, leading to exceptions while raising an exception.
- The syntax `raise A, B, C` hasn't existed since Python 3. The only reason it works is because Cython supports it. Lets get rid of it.
- There was an attempt to convert a certain kind of `KjException` to an `AttributeError`. However, the original exception remains in the context when the new exception is raised. This is confusing. We get rid of the original exception by doing `raise e._to_python() from None`.