### PR TITLE
Corner case for cancelled server methods that raise exceptions

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -76,6 +76,15 @@ cdef class _VoidPromiseFulfiller:
 
 def void_task_done_callback(method_name, _VoidPromiseFulfiller fulfiller, task):
     if fulfiller.fulfiller == NULL:
+        if not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                context = {
+                    'message': f"Cancelled server method {method_name} raised an exception",
+                    'exception': exc,
+                    'task': task,
+                }
+                asyncio.get_running_loop().call_exception_handler(context)
         return
 
     if task.cancelled():


### PR DESCRIPTION
When a server method is cancelled, but it nonetheless raises an exception (other than `CancelledError`), this exception cannot be reported to the caller (because it has cancelled that call).

The only place where it can go is to the asyncio exception handler...