### PR TITLE
Some fixes to the magic import system

### DIFF
--- a/test/schemas/child.capnp
+++ b/test/schemas/child.capnp
@@ -1,0 +1,5 @@
+@0x9afc0f7513269df3;
+
+struct Child {
+  name @0 :Text;
+}

--- a/test/schemas/parent.capnp
+++ b/test/schemas/parent.capnp
@@ -1,0 +1,7 @@
+@0x95c41c96183b9c2f;
+
+using import "/schemas/child.capnp".Child;
+
+struct Parent {
+  child @0 :List(Child);
+}

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -80,7 +80,7 @@ def test_spaces_import():
 
 
 def test_add_import_hook():
-    capnp.add_import_hook([this_dir])
+    capnp.add_import_hook()
 
     # Make sure any previous imports of addressbook_capnp are gone
     capnp.cleanup_global_schema_parser()
@@ -93,7 +93,6 @@ def test_add_import_hook():
 def test_multiple_add_import_hook():
     capnp.add_import_hook()
     capnp.add_import_hook()
-    capnp.add_import_hook([this_dir])
 
     # Make sure any previous imports of addressbook_capnp are gone
     capnp.cleanup_global_schema_parser()
@@ -104,7 +103,7 @@ def test_multiple_add_import_hook():
 
 
 def test_remove_import_hook():
-    capnp.add_import_hook([this_dir])
+    capnp.add_import_hook()
     capnp.remove_import_hook()
 
     if "addressbook_capnp" in sys.modules:
@@ -118,7 +117,12 @@ def test_remove_import_hook():
 def test_bundled_import_hook():
     # stream.capnp should be bundled, or provided by the system capnproto
     capnp.add_import_hook()
-    import stream_capnp  # noqa: F401
+    from capnp import stream_capnp  # noqa: F401
+
+
+def test_nested_import():
+    import schemas.parent_capnp  # noqa: F401
+    import schemas.child_capnp  # noqa: F401
 
 
 async def test_load_capnp(foo):


### PR DESCRIPTION
- Stop adding the directory of every .capnp file to the import path. If a .capnp file wants to import a file in its own directory, it should use a relative import. Fixes #278
- Stop using /usr/include/capnp as an import path. This is incorrect. It should only be /usr/include. People that want to import, for example, `rpc.capnp` should do `import capnp.rpc_capnp` instead of `import rpc_capnp`. This fixes another bug similar to #278.
- Stop allowing additional paths to be specified for magic imports. This leads to inconsistencies. More specifically, the way that a nested import like `ma.mb.mc_capnp` gets imported by python, is to first import `ma`, then import `ma.mb`, and finally `ma.mb.mc_capnp`. Pycapnp's magic importing is only involved in the last step. So any additional paths specified don't work for nested imports. It is very confusing to only have this for non-nested imports. Users with folder layouts that don't follow pythons import paths can still use `capnp.load(.., .., imports=[blah])`.

Possibly this is also a fix for #279 but I cannot verify that.