### PR TITLE
Fix deprecation warning when importing a schema

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -4399,15 +4399,13 @@ class _Loader:
         self.fullname = fullname
         self.path = path
 
-    def load_module(self, fullname):
-        assert self.fullname == fullname, (
-            "invalid module, expected {}, got {}".format(self.fullname, fullname))
-
+    def create_module(self, _spec):
         imports = _capnp_paths + [path if path != '' else '.' for path in _sys.path]
-        module = load(self.path, fullname, imports=imports)
-        _sys.modules[fullname] = module
-
+        module = load(self.path, self.fullname, imports=imports)
         return module
+
+    def exec_module(self, _module):
+        pass
 
 
 class _Importer:


### PR DESCRIPTION
`load_module` has been deprecated since Python 3.4. A warning is issued in recent releases:

> ImportWarning: _Loader.exec_module() not found; falling back to load_module()

See: https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module