### PR TITLE
Include _custom_build in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE.md
 include CHANGELOG.md
 include requirements.txt
 include buildutils/*
+include _custom_build/*
 include capnp/lib/capnp_api.h
 include Pipfile
 include tox.ini


### PR DESCRIPTION
This fixes build issues for installations that cannot use wheels published on PyPI. Issue #364 would be fixed by this.

Python build tools like `python -m build` first build a source distribuiton (sdist) and then use it (and only it) to build a binary wheel from. This doesn't work if one of the build scripts isn't in the sdist however, which was the case prior to this patch.