### PR TITLE
Support python custom message builder and make DynamicStructBuilder's Data type as MemoryView

### DIFF
--- a/capnp/__init__.py
+++ b/capnp/__init__.py
@@ -48,6 +48,7 @@ from .lib.capnp import (
     _InterfaceModule,
     _ListSchema,
     _MallocMessageBuilder,
+    _PyCustomMessageBuilder,
     _PackedFdMessageReader,
     _StreamFdMessageReader,
     _StructModule,

--- a/capnp/includes/PyCustomMessageBuilder.cpp
+++ b/capnp/includes/PyCustomMessageBuilder.cpp
@@ -1,0 +1,54 @@
+#include "PyCustomMessageBuilder.h"
+#include <iostream>
+#include <stdexcept>
+
+namespace capnp {
+
+PyCustomMessageBuilder::PyCustomMessageBuilder(PyObject* allocateSegmentFunc)
+    :capnp::MessageBuilder(),
+      allocateSegmentFunc(allocateSegmentFunc)
+{
+  KJ_REQUIRE(PyCallable_Check(allocateSegmentFunc),
+               "allocateSegmentFunc must be callable");
+  Py_INCREF(allocateSegmentFunc);
+}
+
+PyCustomMessageBuilder::~PyCustomMessageBuilder() noexcept(false) {
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  for (auto* obj : allocatedBuffers) {
+    Py_DECREF(obj);
+  }
+  allocatedBuffers.clear();
+
+  Py_DECREF(allocateSegmentFunc);
+  PyGILState_Release(gstate);
+}
+
+kj::ArrayPtr<capnp::word> PyCustomMessageBuilder::allocateSegment(capnp::uint minimumSize) {
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  KJ_DEFER({ PyGILState_Release(gstate); });
+
+  std::cout << "allocateSegment start test \n";
+
+  PyObject* pyBufObj = PyObject_CallFunction(allocateSegmentFunc, "I", minimumSize);
+  KJ_REQUIRE(pyBufObj, "PyCustomMessageBuilder: allocateSegment failed");
+  allocatedBuffers.push_back(pyBufObj);
+
+
+  Py_buffer view;
+  int bufRes = PyObject_GetBuffer(pyBufObj, &view, PyBUF_SIMPLE);
+  KJ_REQUIRE(bufRes == 0, "PyCustomMessageBuilder: object does not support buffer protocol");
+  KJ_DEFER({ PyBuffer_Release(&view); });
+
+  size_t byteCount = view.len;
+  size_t wordCount = byteCount / sizeof(capnp::word);
+  KJ_REQUIRE(wordCount >= minimumSize, "PyCustomMessageBuilder: buffer too small for minimumSize");
+
+  auto seg = kj::arrayPtr(reinterpret_cast<capnp::word*>(view.buf), wordCount);
+
+  std::cout << "allocateSegment finish test \n";
+  return seg;
+}
+
+}

--- a/capnp/includes/PyCustomMessageBuilder.h
+++ b/capnp/includes/PyCustomMessageBuilder.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Python.h"
+#include <capnp/message.h>
+#include <capnp/serialize.h>
+#include <vector>
+
+namespace capnp {
+
+class PyCustomMessageBuilder : public capnp::MessageBuilder {
+public:
+  explicit PyCustomMessageBuilder(PyObject* allocateSegmentFunc);
+
+  ~PyCustomMessageBuilder() noexcept(false) override;
+
+  kj::ArrayPtr<capnp::word> allocateSegment(capnp::uint minimumSize) override;
+
+private:
+  PyObject* allocateSegmentFunc;
+  std::vector<PyObject*> allocatedBuffers;
+};
+
+}

--- a/capnp/includes/schema_cpp.pxd
+++ b/capnp/includes/schema_cpp.pxd
@@ -714,6 +714,10 @@ cdef extern from "capnp/message.h" namespace " ::capnp":
     enum Void:
         VOID
 
+cdef extern from "PyCustomMessageBuilder.h" namespace " ::capnp":
+    cdef cppclass PyCustomMessageBuilder(MessageBuilder):
+        PyCustomMessageBuilder(PyObject* allocateSegmentFunc)
+
 cdef extern from "capnp/common.h" namespace " ::capnp":
     cdef cppclass word nogil:
         pass

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -698,7 +698,6 @@ cdef to_python_builder(C_DynamicValue.Builder self, object parent):
     elif type == capnp.TYPE_DATA:
         temp_data = self.asData()
         return memoryview.PyMemoryView_FromMemory(<char *> temp_data.begin(), temp_data.size(), buffer.PyBUF_WRITE)
-        # return <bytes> ((<char *> temp_data.begin())[:temp_data.size()])
     elif type == capnp.TYPE_LIST:
         return _DynamicListBuilder()._init(self.asList(), parent)
     elif type == capnp.TYPE_STRUCT:
@@ -769,7 +768,7 @@ cdef _setMemoryview(_DynamicSetterClasses thisptr, field, value):
     cdef C_DynamicValue.Reader temp
     if PyObject_GetBuffer(value, &buf, PyBUF_CONTIG_RO) != 0:
         raise KjException(
-            "cannot get buffer from memory view，for field '{}'".format(field)
+            "cannot get buffer from memory view, for field '{}'".format(field)
         )
     try:
         ptr = capnp.StringPtr(<char *> buf.buf, buf.len)
@@ -790,6 +789,20 @@ cdef _setBytesField(DynamicStruct_Builder thisptr, _StructSchemaField field, val
     cdef C_DynamicValue.Reader temp = C_DynamicValue.Reader(temp_string)
     thisptr.setByField(field.thisptr, temp)
 
+cdef _setMemoryviewField(DynamicStruct_Builder thisptr, _StructSchemaField field, value):
+    cdef Py_buffer buf
+    cdef capnp.StringPtr ptr
+    cdef C_DynamicValue.Reader temp
+    if PyObject_GetBuffer(value, &buf, PyBUF_CONTIG_RO) != 0:
+        raise KjException(
+            "cannot get buffer from memory view, for field '{}'".format(field)
+        )
+    try:
+        ptr = capnp.StringPtr(<char *>buf.buf, buf.len)
+        temp = C_DynamicValue.Reader(ptr)
+        thisptr.setByField(field.thisptr, temp)
+    finally:
+        PyBuffer_Release(&buf)
 
 cdef _setBaseStringField(DynamicStruct_Builder thisptr, _StructSchemaField field, value):
     encoded_value = value.encode('utf-8')
@@ -879,6 +892,8 @@ cdef _setDynamicFieldWithField(DynamicStruct_Builder thisptr, _StructSchemaField
         thisptr.setByField(field.thisptr, temp)
     elif value_type is bytes:
         _setBytesField(thisptr, field, value)
+    elif isinstance(value, BuiltinsMemoryview):
+        _setMemoryviewField(thisptr, field, value)
     elif isinstance(value, basestring):
         _setBaseStringField(thisptr, field, value)
     elif value_type is list:

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -13,8 +13,9 @@ from capnp.helpers.helpers cimport init_capnp_api
 from capnp.includes.capnp_cpp cimport AsyncIoStream, WaitScope, PyPromise, VoidPromise, EventPort, EventLoop, Canceler, PyAsyncIoStream, PromiseFulfiller, VoidPromiseFulfiller, tryReadMessage, writeMessage, makeException, PythonInterfaceDynamicImpl
 from capnp.includes.schema_cpp cimport (MessageReader,)
 
+from builtins import memoryview as BuiltinsMemoryview
 from cpython cimport array, Py_buffer, PyObject_CheckBuffer, memoryview, buffer
-from cpython.buffer cimport PyBUF_SIMPLE, PyBUF_WRITABLE
+from cpython.buffer cimport PyBUF_SIMPLE, PyBUF_WRITABLE, PyBUF_CONTIG_RO
 from cpython.exc cimport PyErr_Clear
 from cython.operator cimport dereference as deref
 from libc.stdlib cimport malloc, free
@@ -696,7 +697,8 @@ cdef to_python_builder(C_DynamicValue.Builder self, object parent):
         return (<char*>temp_text.begin())[:temp_text.size()]
     elif type == capnp.TYPE_DATA:
         temp_data = self.asData()
-        return <bytes>((<char*>temp_data.begin())[:temp_data.size()])
+        return memoryview.PyMemoryView_FromMemory(<char *> temp_data.begin(), temp_data.size(), buffer.PyBUF_WRITE)
+        # return <bytes> ((<char *> temp_data.begin())[:temp_data.size()])
     elif type == capnp.TYPE_LIST:
         return _DynamicListBuilder()._init(self.asList(), parent)
     elif type == capnp.TYPE_STRUCT:
@@ -761,6 +763,20 @@ cdef _setBytes(_DynamicSetterClasses thisptr, field, value):
     cdef C_DynamicValue.Reader temp = C_DynamicValue.Reader(temp_string)
     thisptr.set(field, temp)
 
+cdef _setMemoryview(_DynamicSetterClasses thisptr, field, value):
+    cdef Py_buffer buf
+    cdef capnp.StringPtr ptr
+    cdef C_DynamicValue.Reader temp
+    if PyObject_GetBuffer(value, &buf, PyBUF_CONTIG_RO) != 0:
+        raise KjException(
+            "cannot get buffer from memory view，for field '{}'".format(field)
+        )
+    try:
+        ptr = capnp.StringPtr(<char *> buf.buf, buf.len)
+        temp = C_DynamicValue.Reader(ptr)
+        thisptr.set(field, temp)
+    finally:
+        PyBuffer_Release(&buf)
 
 cdef _setBaseString(_DynamicSetterClasses thisptr, field, value):
     encoded_value = value.encode('utf-8')
@@ -800,6 +816,8 @@ cdef _setDynamicField(_DynamicSetterClasses thisptr, field, value, parent):
         thisptr.set(field, temp)
     elif value_type is bytes:
         _setBytes(thisptr, field, value)
+    elif isinstance(value, BuiltinsMemoryview):
+        _setMemoryview(thisptr, field, value)
     elif isinstance(value, basestring):
         _setBaseString(thisptr, field, value)
     elif value_type is list:
@@ -3725,6 +3743,10 @@ cdef class _MallocMessageBuilder(_MessageBuilder):
         else:
             self.thisptr = new schema_cpp.MallocMessageBuilder(size)
 
+
+cdef class _PyCustomMessageBuilder(_MessageBuilder):
+    def __init__(self, allocate_seg_func):
+        self.thisptr = new schema_cpp.PyCustomMessageBuilder(<PyObject*>allocate_seg_func)
 
 cdef class _MessageReader:
     """An abstract base class for reading Cap'n Proto messages

--- a/setup.py
+++ b/setup.py
@@ -115,22 +115,10 @@ class build_libcapnp_ext(build_ext_c):
         build_ext_c.build_extension(self, ext)
 
     def run(self):  # noqa: C901
-        # capnp_include = os.environ.get("CAPNP_INCLUDE_DIR")
-        # capnp_lib = os.environ.get("CAPNP_LIB_DIR")
-        # print('test111')
-        # print(capnp_include)
         if self.force_bundled_libcapnp:
             need_build = True
         elif self.force_system_libcapnp:
             need_build = False
-        # elif capnp_include and capnp_lib:
-        #     print(f"Using CAPNP_INCLUDE_DIR={capnp_include}")
-        #     print(f"Using CAPNP_LIB_DIR={capnp_lib}")
-        #     self.include_dirs.insert(0, capnp_include)
-        #     self.library_dirs.insert(0, capnp_lib)
-        #
-        #     need_build = False
-        #     print('test123')
         else:
             # Try to use capnp executable to find include and lib path
             capnp_executable = shutil.which("capnp")

--- a/setup.py
+++ b/setup.py
@@ -115,10 +115,22 @@ class build_libcapnp_ext(build_ext_c):
         build_ext_c.build_extension(self, ext)
 
     def run(self):  # noqa: C901
+        # capnp_include = os.environ.get("CAPNP_INCLUDE_DIR")
+        # capnp_lib = os.environ.get("CAPNP_LIB_DIR")
+        # print('test111')
+        # print(capnp_include)
         if self.force_bundled_libcapnp:
             need_build = True
         elif self.force_system_libcapnp:
             need_build = False
+        # elif capnp_include and capnp_lib:
+        #     print(f"Using CAPNP_INCLUDE_DIR={capnp_include}")
+        #     print(f"Using CAPNP_LIB_DIR={capnp_lib}")
+        #     self.include_dirs.insert(0, capnp_include)
+        #     self.library_dirs.insert(0, capnp_lib)
+        #
+        #     need_build = False
+        #     print('test123')
         else:
             # Try to use capnp executable to find include and lib path
             capnp_executable = shutil.which("capnp")
@@ -201,6 +213,7 @@ extensions = [
         "*",
         [
             "capnp/helpers/capabilityHelper.cpp",
+            "capnp/includes/PyCustomMessageBuilder.cpp",
             "capnp/lib/*.pyx",
         ],
         extra_compile_args=extra_compile_args,


### PR DESCRIPTION
For resolving this issue:
[issue](https://github.com/capnproto/pycapnp/issues/379)