### PR TITLE
Update wheelbuilding on GH actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           # TODO: Disable building PyPy wheels. If the build system gets modernized, this should be
           # auto-detected based on the Cython dependency.
-          CIBW_SKIP: pp*
+          CIBW_SKIP: pp* cp314-*
           CIBW_TEST_REQUIRES: pytest pytest-asyncio
           CIBW_TEST_COMMAND: pytest {project}
           # Only needed to make the macosx arm64 build work

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           # TODO: Disable building PyPy wheels. If the build system gets modernized, this should be
           # auto-detected based on the Cython dependency.
-          CIBW_SKIP: pp* cp314-*
+          CIBW_SKIP: pp* cp314*
           CIBW_TEST_REQUIRES: pytest pytest-asyncio
           CIBW_TEST_COMMAND: pytest {project}
           # Only needed to make the macosx arm64 build work

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,31 +22,31 @@ jobs:
           - os: ubuntu-latest
             arch: s390x
 
-          - os: macOS-latest
+          - os: macos-13
             arch: x86_64
-          - os: macOS-latest
+          - os: macos-14
             arch: arm64
           # Disabled until someone figures out how to build capnproto for arm64 and x86_64 simultaneously
           # - os: macOS-latest
           #   arch: universal2
 
-          - os: windows-2019
+          - os: windows-2022
             arch: AMD64
-          - os: windows-2019
+          - os: windows-2022
             arch: x86
           # Does not build currently
           # - os: windows-2019
           #   arch: ARM64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.1.4
         with:
           output-dir: wheelhouse
         env:
@@ -68,7 +68,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build sdist
         run: pipx run build --sdist
@@ -82,7 +82,7 @@ jobs:
     name: Lint with flake8 and check black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Lint with flake8 and check black
         run: |


### PR DESCRIPTION
# Context
Github Actions runner infra requires some minor updates to continue building wheels against the currently supported runner images.

The following changes were made:
* Windows Server 2019 has been removed in favour of Windows 2022, the current minimum supported version
* MacOS Latest has been replaced by MacOS 13 (for x86_64) and MacOS 14 (for ARM64). To ensure forward compatibility, use of the older MacOS versions for wheelbuilds is safer (though, forcing compatibility in the compilation process is also an option here).
* Updating the CIBuildWheel versions to ensure support for Py 3.13.
* Py 3.14 is currently disabled, due to async-related failures. 

# Note
The PyPI push action remains commented out, and will likely require a manual release for new wheels.
No Changes have been made to the version-strings in the package to support the above.