### PR TITLE
Make `message.to_dict()` return bytes for DATA type field

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1058,11 +1058,16 @@ cdef _to_dict(msg, bint verbose, bint ordered, bint encode_bytes_as_base64=False
 
     if encode_bytes_as_base64:
         if msg_type is bytes:
-            return base64.b64encode(msg).decode('utf-8')
-        elif msg_type is memoryview:
+            # encode the message as base64 and return utf-8 string
+
+    if encode_bytes_as_base64 and msg_type is bytes:
+        # encode the message as base64 and return utf-8 string
+        return base64.b64encode(msg).decode('utf-8')
+
+    if msg_type is memoryview:
+        if encode_bytes_as_base64:
             return base64.b64encode(bytes(msg)).decode('utf-8')
-    else:
-        if msg_type is memoryview:
+        else:
             return bytes(msg)
 
     return msg

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1056,9 +1056,14 @@ cdef _to_dict(msg, bint verbose, bint ordered, bint encode_bytes_as_base64=False
     if msg_type is _DynamicEnum:
         return str(msg)
 
-    if encode_bytes_as_base64 and msg_type is bytes:
-        # encode the message as base64 and return utf-8 string
-        return base64.b64encode(msg).decode('utf-8')
+    if encode_bytes_as_base64:
+        if msg_type is bytes:
+            return base64.b64encode(msg).decode('utf-8')
+        elif msg_type is memoryview:
+            return base64.b64encode(bytes(msg)).decode('utf-8')
+    else:
+        if msg_type is memoryview:
+            return bytes(msg)
 
     return msg
 

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1056,10 +1056,6 @@ cdef _to_dict(msg, bint verbose, bint ordered, bint encode_bytes_as_base64=False
     if msg_type is _DynamicEnum:
         return str(msg)
 
-    if encode_bytes_as_base64:
-        if msg_type is bytes:
-            # encode the message as base64 and return utf-8 string
-
     if encode_bytes_as_base64 and msg_type is bytes:
         # encode the message as base64 and return utf-8 string
         return base64.b64encode(msg).decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,7 @@ setup(
             "*.capnp",
             "helpers/*.pxd",
             "helpers/*.h",
+            "includes/*.h",
             "includes/*.pxd",
             "lib/*.pxd",
             "lib/*.py",

--- a/test/test_blob_to_dict_base64.py
+++ b/test/test_blob_to_dict_base64.py
@@ -1,5 +1,6 @@
 import os
 import capnp
+import base64
 import pytest
 
 this_dir = os.path.dirname(__file__)
@@ -14,7 +15,7 @@ def test_blob_to_dict(blob_schema):
     blob_value = b"hello world"
     blob = blob_schema.BlobTest(blob=blob_value)
     blob_dict = blob.to_dict(encode_bytes_as_base64=True)
-    assert blob_dict["blob"].tobytes() == blob_value
+    assert base64.b64decode(blob_dict["blob"]) == blob_value
     msg = blob_schema.BlobTest.new_message()
     msg.from_dict(blob_dict)
     assert blob.blob == blob_value


### PR DESCRIPTION
This PR is for resolving this [Regression in 2.2.0: yaml.dump can no longer save capnp messages with Data type fields #385
](https://github.com/capnproto/pycapnp/issues/385)

And also trying to resolve this [PyPI 2.2.0 source distribution missing PyCustomMessageBuilder.h #384
](https://github.com/capnproto/pycapnp/issues/384)

## Background 
Cap’n Proto’s C++ layer exposes Data fields as pointers into the message’s memory. Returning bytes forces an immediate copy of that buffer. To avoid that expensive copy (which is a real performance and memory bottleneck for large messages), I made it return a memoryview instead of bytes. 

However, memoryview is subject to the limitation that they cannot be pickled, but in C++ this is unnecessary.

This can be resolved by modifying the message.to_dict() method, without needing change to user's code.

Please note that the changes in the test case are simply a rollback, not the introduction of any new modifications.


For the `manylinux2014` issue, I added the `py_custom_message_builder.h` to the binary output. Hopefully it can resolve the issue, but I cannot find a way to validate it.