### PR TITLE
Fix test failures on Python 3.14

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           # TODO: Disable building PyPy wheels. If the build system gets modernized, this should be
           # auto-detected based on the Cython dependency.
-          CIBW_SKIP: pp* cp314*
+          CIBW_SKIP: pp*
           CIBW_TEST_REQUIRES: pytest pytest-asyncio
           CIBW_TEST_COMMAND: pytest {project}
           # Only needed to make the macosx arm64 build work

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -440,7 +440,7 @@ SSL/TLS setup effectively wraps the socket transport. You'll need an SSL certifi
 Due to a `bug <https://bugs.python.org/issue36709>`_ in Python 3.8 asyncio client needs to be initialized in a slightly different way::
 
     if __name__ == '__main__':
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         loop.run_until_complete(capnp.run(main(parse_args().host)))
 
 

--- a/examples/async_calculator_server.py
+++ b/examples/async_calculator_server.py
@@ -7,7 +7,6 @@ import logging
 import capnp
 import calculator_capnp
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/examples/async_server.py
+++ b/examples/async_server.py
@@ -7,7 +7,6 @@ import logging
 import capnp
 import thread_capnp
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/examples/async_ssl_calculator_client.py
+++ b/examples/async_ssl_calculator_client.py
@@ -9,7 +9,6 @@ import socket
 import capnp
 import calculator_capnp
 
-
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/examples/async_ssl_calculator_client.py
+++ b/examples/async_ssl_calculator_client.py
@@ -328,5 +328,5 @@ if __name__ == "__main__":
     # Using asyncio.run hits an asyncio ssl bug
     # https://bugs.python.org/issue36709
     # asyncio.run(main(parse_args().host), loop=loop, debug=True)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(capnp.run(main(parse_args().host)))

--- a/examples/async_ssl_calculator_server.py
+++ b/examples/async_ssl_calculator_server.py
@@ -10,7 +10,6 @@ import socket
 import capnp
 import calculator_capnp
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/examples/async_ssl_client.py
+++ b/examples/async_ssl_client.py
@@ -71,5 +71,5 @@ if __name__ == "__main__":
     # Using asyncio.run hits an asyncio ssl bug
     # https://bugs.python.org/issue36709
     # asyncio.run(main(parse_args().host), loop=loop, debug=True)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(capnp.run(main(parse_args().host)))

--- a/examples/async_ssl_server.py
+++ b/examples/async_ssl_server.py
@@ -10,7 +10,6 @@ import socket
 import capnp
 import thread_capnp
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ sys.path.insert(1, _this_dir)
 from buildutils.build import build_libcapnp
 from buildutils.bundle import fetch_libcapnp
 
-
 MAJOR = 2
 MINOR = 2
 MICRO = 2


### PR DESCRIPTION
As documented at
https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop, `get_event_loop` now fails if there is no active event loop. Since there will never already be one at the top level of a file anyway, explicitly create a new one every time.