### PR TITLE
Fix memory leak in _DynamicCapabilityClient._send_helper()

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -2320,7 +2320,9 @@ cdef class _DynamicCapabilityClient:
 
         self._set_fields(request, name, args, kwargs)
 
-        return _RemotePromise()._init(request.send(), self)
+        cdef _RemotePromise result = _RemotePromise()._init(request.send(), self)
+        del request
+        return result
 
     cpdef _request_helper(self, name, firstSegmentWordSize, args, kwargs):
         # if word_count is None:


### PR DESCRIPTION
  The heap-allocated Request object was never freed after send().
  Each RPC call leaked ~72 bytes, growing linearly with usage.

  Added del request after request.send() to free the Request once
  the RemotePromise has been constructed.