### PR TITLE
Fix: `get_data_as_view` retaion the backing reader/builder even after the view is released, leading to memory leakage

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -54,6 +54,8 @@ _CAPNP_VERSION_MINOR = capnp.CAPNP_VERSION_MINOR
 _CAPNP_VERSION_MICRO = capnp.CAPNP_VERSION_MICRO
 _CAPNP_VERSION = capnp.CAPNP_VERSION
 
+cdef char _EMPTY_DATA_VIEW_SENTINEL = 0
+
 cdef dict _type_registry = {}
 
 
@@ -1297,6 +1299,9 @@ cdef class _DynamicStructReader:
         """
         cdef C_DynamicValue.Reader val
         cdef capnp.Data.Reader temp_data
+        cdef Py_buffer buf
+        cdef void* data_ptr
+        cdef size_t data_size
 
         try:
             val = self.thisptr.get(field)
@@ -1307,10 +1312,14 @@ cdef class _DynamicStructReader:
             raise TypeError("Field '{}' is not a DATA field".format(field))
 
         temp_data = val.asData()
+        data_ptr = <void*>temp_data.begin()
+        data_size = temp_data.size()
+
+        if data_size == 0 and data_ptr == NULL:
+            data_ptr = <void*>&_EMPTY_DATA_VIEW_SENTINEL
 
         # Return read-only memoryview
-        cdef Py_buffer buf
-        if PyBuffer_FillInfo(&buf, self, <void*>temp_data.begin(), temp_data.size(), 1, PyBUF_CONTIG_RO) < 0:
+        if PyBuffer_FillInfo(&buf, self, data_ptr, data_size, 1, PyBUF_CONTIG_RO) < 0:
             raise KjException("Failed to create buffer info")
         return PyMemoryView_FromBuffer(&buf)
 
@@ -1739,6 +1748,9 @@ cdef class _DynamicStructBuilder:
         """
         cdef C_DynamicValue.Builder val
         cdef capnp.Data.Builder temp_data
+        cdef Py_buffer buf
+        cdef void* data_ptr
+        cdef size_t data_size
 
         try:
             val = self.thisptr.get(field)
@@ -1749,10 +1761,14 @@ cdef class _DynamicStructBuilder:
             raise TypeError("Field '{}' is not a DATA field".format(field))
 
         temp_data = val.asData()
+        data_ptr = <void*>temp_data.begin()
+        data_size = temp_data.size()
+
+        if data_size == 0 and data_ptr == NULL:
+            data_ptr = <void*>&_EMPTY_DATA_VIEW_SENTINEL
 
         # Return writable memoryview
-        cdef Py_buffer buf
-        if PyBuffer_FillInfo(&buf, self, <void*>temp_data.begin(), temp_data.size(), 0, PyBUF_WRITABLE) < 0:
+        if PyBuffer_FillInfo(&buf, self, data_ptr, data_size, 0, PyBUF_WRITABLE) < 0:
             raise KjException("Failed to create buffer info")
         return PyMemoryView_FromBuffer(&buf)
 

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -16,7 +16,7 @@ from capnp.includes.schema_cpp cimport (MessageReader,)
 from builtins import memoryview as BuiltinsMemoryview
 from cpython cimport array, Py_buffer, PyObject_CheckBuffer
 from cpython.buffer cimport PyBUF_SIMPLE, PyBUF_WRITABLE, PyBUF_WRITE, PyBUF_READ, PyBUF_CONTIG_RO, PyBuffer_FillInfo
-from cpython.memoryview cimport PyMemoryView_FromMemory, PyMemoryView_FromBuffer
+from cpython.memoryview cimport PyMemoryView_FromMemory, PyMemoryView_FromObject
 from cpython.bytes cimport PyBytes_FromStringAndSize
 from cpython.exc cimport PyErr_Clear
 from cpython.pyport cimport PY_SSIZE_T_MAX
@@ -1178,20 +1178,24 @@ cdef class _MessageSize:
 
 
 @cython.internal
-cdef class _SegmentView:
-    cdef object _builder
+cdef class _BorrowedBufferView:
+    """Buffer-protocol exporter that pins an owner while a view borrows its memory."""
+    cdef object _owner
     cdef const char* _ptr
     cdef Py_ssize_t _size
+    cdef bint _readonly
 
-    cdef _init(self, object builder, const char* ptr, Py_ssize_t size):
-        self._builder = builder
-        self._ptr = ptr
+    cdef _init(self, object owner, const void* ptr, Py_ssize_t size, bint readonly):
+        self._owner = owner
+        self._ptr = <const char*>ptr
         self._size = size
+        self._readonly = readonly
         return self
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
-        if PyBuffer_FillInfo(buffer, self, <void*>self._ptr, self._size, 1, flags) < 0:
-            raise BufferError("Failed to create segment buffer view")
+        if PyBuffer_FillInfo(buffer, self, <void*>self._ptr, self._size,
+                             self._readonly, flags) < 0:
+            raise BufferError("Failed to create borrowed buffer view")
 
     def __releasebuffer__(self, Py_buffer *buffer):
         pass
@@ -1200,7 +1204,56 @@ cdef class _SegmentView:
         return self._size
 
     def __repr__(self):
-        return '<capnp segment view size=%d>' % self._size
+        if self._readonly:
+            return '<capnp borrowed buffer view size=%d read-only>' % self._size
+        return '<capnp borrowed buffer view size=%d writable>' % self._size
+
+
+cdef inline object _memoryview_borrowing(object owner, void* ptr, Py_ssize_t size,
+                                         bint readonly):
+    cdef _BorrowedBufferView exporter
+    exporter = _BorrowedBufferView()._init(owner, ptr, size, readonly)
+    return PyMemoryView_FromObject(exporter)
+
+
+cdef void _data_field_ptr_reader(_DynamicStructReader self, field,
+                                 void** data_ptr, size_t* data_size) except *:
+    cdef C_DynamicValue.Reader val
+    cdef capnp.Data.Reader temp_data
+
+    try:
+        val = self.thisptr.get(field)
+    except KjException as e:
+        raise e._to_python() from None
+
+    if val.getType() != capnp.TYPE_DATA:
+        raise TypeError("Field '{}' is not a DATA field".format(field))
+
+    temp_data = val.asData()
+    data_ptr[0] = <void*>temp_data.begin()
+    data_size[0] = temp_data.size()
+    if data_size[0] == 0 and data_ptr[0] == NULL:
+        data_ptr[0] = <void*>&_EMPTY_DATA_VIEW_SENTINEL
+
+
+cdef void _data_field_ptr_builder(_DynamicStructBuilder self, field,
+                                  void** data_ptr, size_t* data_size) except *:
+    cdef C_DynamicValue.Builder val
+    cdef capnp.Data.Builder temp_data
+
+    try:
+        val = self.thisptr.get(field)
+    except KjException as e:
+        raise e._to_python() from None
+
+    if val.getType() != capnp.TYPE_DATA:
+        raise TypeError("Field '{}' is not a DATA field".format(field))
+
+    temp_data = val.asData()
+    data_ptr[0] = <void*>temp_data.begin()
+    data_size[0] = temp_data.size()
+    if data_size[0] == 0 and data_ptr[0] == NULL:
+        data_ptr[0] = <void*>&_EMPTY_DATA_VIEW_SENTINEL
 
 
 @cython.internal
@@ -1221,10 +1274,11 @@ cdef class _SegmentViews:
             if word_count > <size_t>(PY_SSIZE_T_MAX // 8):
                 raise OverflowError("segment is too large to expose as a Python buffer")
             byte_count = <Py_ssize_t>(8 * word_count)
-            self._views.append(_SegmentView()._init(
+            self._views.append(_BorrowedBufferView()._init(
                 builder,
-                <const char*>segments[i].begin(),
-                byte_count))
+                segments[i].begin(),
+                byte_count,
+                True))
         return self
 
     def __getitem__(self, index):
@@ -1297,45 +1351,18 @@ cdef class _DynamicStructReader:
         """Efficiently get a read-only memoryview for a DATA field without copying.
 
         .. warning::
-            The returned memoryview *borrows* memory owned by this message. It stays valid only
-            while both the memoryview (and any object derived from it) and this reader are alive;
-            the reader keeps the underlying message buffer pinned for that duration. Do not let
-            the message be mutated underneath an outstanding view.
+            The returned memoryview *borrows* memory owned by this message. It stays valid while
+            the memoryview (and any object derived from it) is alive; an internal exporter pins
+            this reader for that duration. Do not let the message be mutated underneath an
+            outstanding view.
 
         An unset/empty DATA field yields a valid, zero-length view (it does not raise).
         """
-        cdef C_DynamicValue.Reader val
-        cdef capnp.Data.Reader temp_data
-        cdef Py_buffer buf
         cdef void* data_ptr
         cdef size_t data_size
 
-        try:
-            val = self.thisptr.get(field)
-        except KjException as e:
-            raise e._to_python() from None
-
-        if val.getType() != capnp.TYPE_DATA:
-            raise TypeError("Field '{}' is not a DATA field".format(field))
-
-        temp_data = val.asData()
-        data_ptr = <void*>temp_data.begin()
-        data_size = temp_data.size()
-
-        if data_size == 0 and data_ptr == NULL:
-            data_ptr = <void*>&_EMPTY_DATA_VIEW_SENTINEL
-
-        # Return read-only memoryview
-        if PyBuffer_FillInfo(&buf, self, data_ptr, data_size, 1, PyBUF_CONTIG_RO) < 0:
-            raise KjException("Failed to create buffer info")
-        # PyBuffer_FillInfo took a reference to `self` via buf.obj. If building the memoryview
-        # fails, release it so we don't leak that reference. PyBuffer_Release only decrements
-        # buf.obj; it does not free buf.buf (including when buf.buf points at the sentinel).
-        try:
-            return PyMemoryView_FromBuffer(&buf)
-        except Exception:
-            PyBuffer_Release(&buf)
-            raise
+        _data_field_ptr_reader(self, field, &data_ptr, &data_size)
+        return _memoryview_borrowing(self, data_ptr, <Py_ssize_t>data_size, True)
 
     cpdef _which_str(self):
         try:
@@ -1775,47 +1802,21 @@ cdef class _DynamicStructBuilder:
 
         .. warning::
             The returned memoryview *borrows* mutable memory owned by this message builder. It is
-            only valid while both the memoryview (and any object derived from it) and this builder
-            are alive. Do NOT mutate, re-set, reset, or reuse the builder while a view is
-            outstanding -- including calls that may allocate (e.g. getting an unset pointer/struct/
-            list field), since those can relocate or stale the borrowed memory. Sharing a view
-            across threads or ``await`` points while the builder may change is a data race.
+            valid while the memoryview (and any object derived from it) is alive; an internal
+            exporter pins this builder for that duration. Do NOT mutate, re-set, reset, or reuse the
+            builder while a view is outstanding -- including calls that may allocate (e.g. getting
+            an unset pointer/struct/list field), since those can relocate or stale the borrowed
+            memory. Sharing a view across threads or ``await`` points while the builder may change
+            is a data race.
 
         An unset/empty DATA field yields a valid but zero-length view (writes are no-ops); to write
         into the field, initialize it to the desired size first.
         """
-        cdef C_DynamicValue.Builder val
-        cdef capnp.Data.Builder temp_data
-        cdef Py_buffer buf
         cdef void* data_ptr
         cdef size_t data_size
 
-        try:
-            val = self.thisptr.get(field)
-        except KjException as e:
-            raise e._to_python() from None
-
-        if val.getType() != capnp.TYPE_DATA:
-            raise TypeError("Field '{}' is not a DATA field".format(field))
-
-        temp_data = val.asData()
-        data_ptr = <void*>temp_data.begin()
-        data_size = temp_data.size()
-
-        if data_size == 0 and data_ptr == NULL:
-            data_ptr = <void*>&_EMPTY_DATA_VIEW_SENTINEL
-
-        # Return writable memoryview
-        if PyBuffer_FillInfo(&buf, self, data_ptr, data_size, 0, PyBUF_WRITABLE) < 0:
-            raise KjException("Failed to create buffer info")
-        # PyBuffer_FillInfo took a reference to `self` via buf.obj. If building the memoryview
-        # fails, release it so we don't leak that reference. PyBuffer_Release only decrements
-        # buf.obj; it does not free buf.buf (including when buf.buf points at the sentinel).
-        try:
-            return PyMemoryView_FromBuffer(&buf)
-        except Exception:
-            PyBuffer_Release(&buf)
-            raise
+        _data_field_ptr_builder(self, field, &data_ptr, &data_size)
+        return _memoryview_borrowing(self, data_ptr, <Py_ssize_t>data_size, False)
 
     cpdef as_reader(self):
         """A method for casting this Builder to a Reader

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1294,8 +1294,15 @@ cdef class _DynamicStructReader:
         return self.thisptr.hasByField(field.thisptr)
 
     cpdef get_data_as_view(self, field):
-        """
-        Efficiently get a read-only memoryview for a DATA field without copying.
+        """Efficiently get a read-only memoryview for a DATA field without copying.
+
+        .. warning::
+            The returned memoryview *borrows* memory owned by this message. It stays valid only
+            while both the memoryview (and any object derived from it) and this reader are alive;
+            the reader keeps the underlying message buffer pinned for that duration. Do not let
+            the message be mutated underneath an outstanding view.
+
+        An unset/empty DATA field yields a valid, zero-length view (it does not raise).
         """
         cdef C_DynamicValue.Reader val
         cdef capnp.Data.Reader temp_data
@@ -1547,8 +1554,21 @@ cdef class _DynamicStructBuilder:
     cpdef to_segment_views(_DynamicStructBuilder self):
         """Returns the struct's containing message as zero-copy, read-only segment views.
 
-        The returned views borrow memory from the message builder. Do not mutate, reset, or reuse
-        the builder while the views are still in use.
+        The returned object is a sequence of read-only buffer-protocol views, one per output
+        segment. Each view borrows memory owned by the message builder; the segment pointers and
+        sizes are captured eagerly at call time (a snapshot).
+
+        .. warning::
+            The views (and any buffer exported from them, e.g. by ``memoryview()`` or by a
+            consumer that holds them) keep the builder pinned and remain valid only while no
+            mutation happens. Do NOT mutate, re-set, reset, or reuse the builder while any view or
+            exported buffer is still alive -- this includes calls that may allocate (e.g. getting
+            an unset pointer/struct/list field). Mutating after the snapshot can grow/relocate
+            segments, leaving the views pointing at stale or truncated data. Sharing the views
+            across threads or ``await`` points while the builder may change is a data race.
+
+            Lifetime is enforced only by buffer-protocol reference counting (memory is not freed
+            while a view is held); correctness of the *contents* is the caller's responsibility.
 
         :rtype: sequence
         """
@@ -1747,11 +1767,22 @@ cdef class _DynamicStructBuilder:
         return _DynamicOrphan()._init(self.thisptr.disown(field), self._parent)
 
     cpdef get_data_as_view(self, field):
-        """
-        Efficiently get a writable memoryview for a DATA field without copying.
+        """Efficiently get a writable memoryview for a DATA field without copying.
 
-        This allows in-place modification of the underlying buffer:
-        msg.get_data_as_view('myField')[0] = 0xFF
+        This allows in-place modification of the underlying buffer::
+
+            msg.get_data_as_view('myField')[0] = 0xFF
+
+        .. warning::
+            The returned memoryview *borrows* mutable memory owned by this message builder. It is
+            only valid while both the memoryview (and any object derived from it) and this builder
+            are alive. Do NOT mutate, re-set, reset, or reuse the builder while a view is
+            outstanding -- including calls that may allocate (e.g. getting an unset pointer/struct/
+            list field), since those can relocate or stale the borrowed memory. Sharing a view
+            across threads or ``await`` points while the builder may change is a data race.
+
+        An unset/empty DATA field yields a valid but zero-length view (writes are no-ops); to write
+        into the field, initialize it to the desired size first.
         """
         cdef C_DynamicValue.Builder val
         cdef capnp.Data.Builder temp_data

--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1321,7 +1321,14 @@ cdef class _DynamicStructReader:
         # Return read-only memoryview
         if PyBuffer_FillInfo(&buf, self, data_ptr, data_size, 1, PyBUF_CONTIG_RO) < 0:
             raise KjException("Failed to create buffer info")
-        return PyMemoryView_FromBuffer(&buf)
+        # PyBuffer_FillInfo took a reference to `self` via buf.obj. If building the memoryview
+        # fails, release it so we don't leak that reference. PyBuffer_Release only decrements
+        # buf.obj; it does not free buf.buf (including when buf.buf points at the sentinel).
+        try:
+            return PyMemoryView_FromBuffer(&buf)
+        except Exception:
+            PyBuffer_Release(&buf)
+            raise
 
     cpdef _which_str(self):
         try:
@@ -1770,7 +1777,14 @@ cdef class _DynamicStructBuilder:
         # Return writable memoryview
         if PyBuffer_FillInfo(&buf, self, data_ptr, data_size, 0, PyBUF_WRITABLE) < 0:
             raise KjException("Failed to create buffer info")
-        return PyMemoryView_FromBuffer(&buf)
+        # PyBuffer_FillInfo took a reference to `self` via buf.obj. If building the memoryview
+        # fails, release it so we don't leak that reference. PyBuffer_Release only decrements
+        # buf.obj; it does not free buf.buf (including when buf.buf points at the sentinel).
+        try:
+            return PyMemoryView_FromBuffer(&buf)
+        except Exception:
+            PyBuffer_Release(&buf)
+            raise
 
     cpdef as_reader(self):
         """A method for casting this Builder to a Reader

--- a/test/test_get_data_view.py
+++ b/test/test_get_data_view.py
@@ -152,6 +152,33 @@ def test_corner_cases_values(all_types):
     assert msg.get_data_as_view("dataField").tobytes() == binary_data
 
 
+def test_uninitialized_data_get_view(all_types):
+    """
+    Default DATA fields should expose an empty memoryview instead of failing on a NULL buffer pointer.
+    """
+    builder = all_types.TestAllTypes.new_message()
+    builder_view = builder.get_data_as_view("dataField")
+
+    assert isinstance(builder_view, memoryview)
+    assert builder_view.readonly is False
+    assert len(builder_view) == 0
+    assert builder_view.tobytes() == b""
+
+    reader = all_types.TestAllTypes.new_message().as_reader()
+    reader_view = reader.get_data_as_view("dataField")
+
+    assert isinstance(reader_view, memoryview)
+    assert reader_view.readonly is True
+    assert len(reader_view) == 0
+    assert reader_view.tobytes() == b""
+
+    with pytest.raises(IndexError):
+        builder_view[0] = 0xFF
+
+    with pytest.raises(ValueError):
+        builder_view[0:1] = b"\xff"
+
+
 def test_error_wrong_type(all_types):
     """
     Test error handling: Calling get_data_as_view on non-Data fields.

--- a/test/test_get_data_view.py
+++ b/test/test_get_data_view.py
@@ -1,4 +1,8 @@
 import os
+import tempfile
+import weakref
+from pathlib import Path
+
 import pytest
 import capnp
 import sys
@@ -233,3 +237,56 @@ def test_view_keeps_message_alive(all_types):
     gc.collect()
 
     assert view.tobytes() == expected_data
+
+
+def test_data_view_exports_through_buffer_exporter(all_types):
+    """Returned memoryviews should pin an internal exporter, not bare pointers."""
+    msg = all_types.TestAllTypes.new_message()
+    msg.dataField = b"exporter_check"
+    view = msg.get_data_as_view("dataField")
+
+    assert isinstance(view, memoryview)
+    assert view.obj is not None
+    assert len(view.obj) == len(view)
+
+
+def test_data_view_survives_del_builder(all_types):
+    msg = all_types.TestAllTypes.new_message()
+    msg.dataField = b"persistence_check"
+    view = msg.get_data_as_view("dataField")
+
+    del msg
+    gc.collect()
+
+    assert view.tobytes() == b"persistence_check"
+
+
+def test_data_view_releases_packed_payload():
+    schema_text = """
+    @0x9d7d4f087df9b6e1;
+    struct BlobMsg {
+      data @0 :Data;
+    }
+    """
+
+    class Payload(bytearray):
+        pass
+
+    td = tempfile.TemporaryDirectory()
+    path = Path(td.name) / "blob.capnp"
+    path.write_text(schema_text)
+    schema = capnp.load(str(path))
+    try:
+        payload = Payload(schema.BlobMsg.new_message(data=b"x" * 4096).to_bytes_packed())
+        payload_ref = weakref.ref(payload)
+
+        reader = schema.BlobMsg.from_bytes_packed(payload)
+        view = reader.get_data_as_view("data")
+        view.release()
+
+        del view, reader, payload
+        gc.collect()
+
+        assert payload_ref() is None
+    finally:
+        td.cleanup()


### PR DESCRIPTION
# pycapnp `get_data_as_view()` Memory Retention Issue

`get_data_as_view()` appears to retain the backing reader/builder after the memoryview is released

## Environment

- pycapnp: `2.2.3` (original report); re-verified on `2.2.4`
- Python: `3.11` (original report); re-verified on `3.10` (venv)
- OS: Ubuntu 22.04 x86_64 / WSL2

## Summary

Calling `get_data_as_view()` on a `Data` field seems to keep the backing Cap'n Proto reader/builder alive even after:

- the returned `memoryview` is deleted
- `memoryview.release()` is called
- the reader/builder object is deleted
- `gc.collect()` and `malloc_trim(0)` are called

For packed readers, this also keeps the original packed input buffer alive. This causes linear RSS growth when decoding messages with large `Data` fields in a loop.

**Verification status: confirmed.** The reproducer below was re-run locally and produced identical numbers to the original report.

**Fix status: implemented** in commit `ded8d02` (`fix: pin DATA field views via shared buffer exporter`). See [Implementation](#implementation) and [Testing](#testing).

## Expected Behavior

### Intended lifetime semantics

The desired contract for the returned `memoryview` (`mv`) is:

1. **While `mv` is alive** (Python refcount > 0): the underlying buffer must remain valid and must not be freed, even if the user deletes their Python variable for the reader/builder.
2. **Once `mv` is gone** (`del mv`, or refcount reaches 0 after `mv.release()`): the underlying buffer should become immediately collectible, even if reader/builder no longer exist in Python.

In other words, `mv` should pin the backing storage for the duration of its own lifetime, and release that pin when `mv` itself is destroyed.

### Naive reference chain

A natural mental model is:

```text
mv ──ref──> reader/builder ──._parent──> _PackedMessageReaderBytes / _MessageBuilder ──> payload / allocator
```

For packed readers the full chain is:

```text
mv ──> _DynamicStructReader ──._parent──> _PackedMessageReaderBytes ──> input bytes + C++ PackedMessageReader
```

## Actual Behavior

The backing objects remain alive after `view.release()` and `del view`.

Observed with a 4 MiB `Data` field:

```text
reader_decode_only:                  +0.08 MiB/iter
reader_get_data_as_view_release:     +8.08 MiB/iter
builder_get_data_as_view_release:    +4.01 MiB/iter

view type: <class 'memoryview'> nbytes: 4194304 obj: None
payload alive after reader view release/del: True
```

Re-verification on pycapnp 2.2.4 (Python 3.10, WSL2):

```text
reader_decode_only:                  +0.08 MiB/iter
reader_get_data_as_view_release:     +8.08 MiB/iter
builder_get_data_as_view_release:    +4.01 MiB/iter

view type: <class 'memoryview'> nbytes: 4194304 obj: None
payload alive after reader view release/del: True
```

`from_bytes_packed()` alone does not leak. The leak appears only after calling `reader.get_data_as_view("data")`.

## Minimal Reproducer

```python
from __future__ import annotations

import ctypes
import gc
import multiprocessing as mp
import tempfile
import weakref
from pathlib import Path

import capnp

SCHEMA_TEXT = """
@0x9d7d4f087df9b6e1;
struct BlobMsg {
  data @0 :Data;
}
"""

RAW = 4 * 1024 * 1024
ITERS = 20


class Payload(bytearray):
    pass


def trim() -> None:
    gc.collect()
    try:
        ctypes.CDLL("libc.so.6").malloc_trim(0)
    except OSError:
        pass


def rss_mb() -> float:
    with open("/proc/self/status") as f:
        for line in f:
            if line.startswith("VmRSS:"):
                return int(line.split()[1]) / 1024.0
    raise RuntimeError("VmRSS not found")


def load_schema():
    td = tempfile.TemporaryDirectory()
    path = Path(td.name) / "blob.capnp"
    path.write_text(SCHEMA_TEXT)
    return td, capnp.load(str(path))


def make_packed(schema) -> bytes:
    msg = schema.BlobMsg.new_message()
    msg.data = b"\x55" * RAW
    return msg.to_bytes_packed()


def loop(case: str, q) -> None:
    td, schema = load_schema()
    try:
        trim()
        base = rss_mb()

        for _ in range(ITERS):
            if case == "reader_decode_only":
                packed = make_packed(schema)
                reader = schema.BlobMsg.from_bytes_packed(packed)
                _ = len(reader.data)
                del reader, packed

            elif case == "reader_get_data_as_view_release":
                packed = make_packed(schema)
                reader = schema.BlobMsg.from_bytes_packed(packed)
                view = reader.get_data_as_view("data")
                _ = len(view)
                view.release()
                del view, reader, packed

            elif case == "builder_get_data_as_view_release":
                builder = schema.BlobMsg.new_message()
                builder.init("data", RAW)
                view = builder.get_data_as_view("data")
                view[:] = b"\x55" * RAW
                view.release()
                del view, builder

            trim()

        end = rss_mb()
        q.put((case, base, end, end - base, (end - base) / ITERS))
    finally:
        td.cleanup()


def run(case: str):
    q = mp.Queue()
    p = mp.Process(target=loop, args=(case, q))
    p.start()
    p.join()
    if p.exitcode != 0:
        raise SystemExit(p.exitcode)
    return q.get()


def weakref_reader_case() -> bool:
    td, schema = load_schema()
    try:
        payload = Payload(make_packed(schema))
        ref = weakref.ref(payload)

        reader = schema.BlobMsg.from_bytes_packed(payload)
        view = reader.get_data_as_view("data")

        print("view type:", type(view), "nbytes:", view.nbytes, "obj:", view.obj)

        view.release()
        del view, reader, payload
        trim()

        return ref() is not None
    finally:
        td.cleanup()


print("pycapnp:", capnp.__version__)
print(f"raw_mib={RAW / 1024 / 1024:.1f}, iterations={ITERS}")

for case in [
    "reader_decode_only",
    "reader_get_data_as_view_release",
    "builder_get_data_as_view_release",
]:
    c, base, end, delta, per_iter = run(case)
    print(f"{c}: {base:.1f}->{end:.1f} MiB delta={delta:+.1f} per_iter={per_iter:+.2f}")

print("payload alive after reader view release/del:", weakref_reader_case())
```

## Analysis

### Buggy implementation (before fix)

In `capnp/lib/capnp.pyx`, both reader and builder `get_data_as_view()` follow the same pattern:

```python
PyBuffer_FillInfo(&buf, self, data_ptr, data_size, readonly, flags)
return PyMemoryView_FromBuffer(&buf)   # success path: no PyBuffer_Release(&buf)
```

The comments in the source correctly note that `PyBuffer_FillInfo` takes a reference to `self` via `buf.obj`, and that `PyBuffer_Release(&buf)` is called only on the **exception** path.

### Root cause: leaked `Py_buffer` reference

Per the [Python C API](https://docs.python.org/3/c-api/memoryview.html#c.PyMemoryView_FromBuffer):

> `PyMemoryView_FromBuffer(view)` wraps the given buffer structure. The caller retains ownership of the buffer structure `view` and **must** call `PyBuffer_Release(view)` when `view` is no longer needed.

The call sequence inside `get_data_as_view()` is:

1. `PyBuffer_FillInfo(&buf, self, ptr, len, ...)` — `INCREF(self)` via `buf.obj`
2. `PyMemoryView_FromBuffer(&buf)` — copies the raw pointer into a new `memoryview` object
3. **Missing:** `PyBuffer_Release(&buf)` on the success path

Without step 3, each call permanently leaks one reference to the reader/builder. After `del view, reader`, that leaked reference keeps the entire chain alive (reader → `_PackedMessageReaderBytes` → packed input buffer).

This explains:

- `+8 MiB/iter` for packed readers (~4 MiB payload + ~4 MiB decoded message)
- `+4 MiB/iter` for builders (message segment only)
- `weakref payload` still alive after `view.release()` and `del view, reader`

### `PyMemoryView_FromBuffer` does NOT pin the exporter

CPython 3.11 source (`Objects/memoryobject.c`) makes an important distinction:

```c
/* info->obj is either NULL or a borrowed reference. This reference
   should not be decremented in PyBuffer_Release(). */
mbuf->master = *info;
mbuf->master.obj = NULL;
```

Key points:

- `PyMemoryView_FromBuffer()` copies the raw pointer but **forces `master.obj = NULL`**
- The returned `memoryview` therefore has **`mv.obj is None`** and does **not** hold a Python reference to the reader/builder
- `PyMemoryView_GET_BASE()` also returns `NULL` for views created this way

So the naive chain `mv ──ref──> reader` **does not exist** in the current implementation. The `memoryview` is a bare pointer view, not an exporter-backed view.

Additionally, the [buffer protocol docs](https://docs.python.org/3/c-api/buffer.html#c.PyBuffer_FillInfo) state that when `PyBuffer_FillInfo` is **not** used inside a `getbufferproc`, the `exporter` argument **must be `NULL`**. The current code passes `self` as exporter outside of `getbufferproc`, which is outside the documented contract.

### Reference counts (buggy vs fixed)

Assume a single Python variable `reader` pointing at the struct reader.

| Stage | `mv` refcount | `reader` delta vs baseline | Notes |
|-------|---------------|----------------------------|-------|
| Before call | — | 0 | baseline |
| After `get_data_as_view()` (**buggy**) | **1** | **+1 (leaked)** | `PyMemoryView_FromBuffer` bare pointer; local `buf` never released |
| After `get_data_as_view()` (**fixed**) | **1** | **+1 (via exporter pin)** | `mv.obj` holds exporter; exporter._owner holds reader |
| After `del mv` (**buggy**) | 0 | **+1 (still leaked)** | leaked ref keeps reader/payload alive |
| After `del mv` (**fixed**) | 0 | **0** | reader collectable if no other refs |

Measured on pycapnp 2.2.4 (Python 3.10):

```text
# Buggy build
reader base=3, with mv=4 (+1), after del mv=4 (+1)
view.obj: None

# Fixed build (_BorrowedBufferView + PyMemoryView_FromObject)
reader base=3, with mv=4 (+1), after del mv=3 (+0)
view.obj: <capnp borrowed buffer view ...>
```

After the fix, the `+1` while `mv` is alive is intentional (exporter pins reader). After `del mv`, the pin is released and memory becomes collectable.

### Lifetime semantics experiments

Additional tests were run to check the two intended lifetime rules.

#### Case 1: `del reader`, keep `mv`

```python
mv = reader.get_data_as_view("data")
del reader
len(mv)  # still works
```

| Build | `mv` usable after `del reader`? | payload alive while `mv` alive? |
|-------|--------------------------------|--------------------------------|
| Buggy | Yes | Yes |
| Fixed | Yes | Yes |

After the fix, this works by design: `mv → exporter → reader` keeps the reader object alive even when the user's `reader` variable is deleted.

#### Case 2: `del reader`, then `del mv` — should release buf

| Build | payload collected? |
|-------|--------------------|
| Buggy | **No** |
| Fixed | **Yes** |

#### Case 3: loop 20× (`del reader` then `del mv` each iteration)

| Build | RSS per iteration |
|-------|-------------------|
| Buggy | +8.00 MiB/iter |
| Fixed | +0.00 MiB/iter |

## Implementation

Commit: `fix: pin DATA field views via shared buffer exporter`

The fix generalizes the existing `_SegmentView` infrastructure so that `get_data_as_view()` and `to_segment_views()` share one buffer-protocol exporter class. The old `PyBuffer_FillInfo` + `PyMemoryView_FromBuffer` path is removed entirely from `get_data_as_view()`.

### Design

The `_SegmentView` helper in `capnp/lib/capnp.pyx` already implemented the correct buffer-protocol pattern:

```text
consumer ──> memoryview ──ref──> exporter ──._owner──> message / struct ──> backing storage
```

Both APIs now share infrastructure but keep different public return shapes:

| API | Owner pinned | Read-only | Public return type |
|-----|--------------|-----------|-------------------|
| `to_segment_views()` | `_MessageBuilder` | always | sequence of exporters |
| `get_data_as_view()` (reader) | `_DynamicStructReader` | yes | `memoryview` |
| `get_data_as_view()` (builder) | `_DynamicStructBuilder` | no | `memoryview` |

### `_BorrowedBufferView`

`_SegmentView` was generalized to `_BorrowedBufferView`: a generic exporter with `_owner`, `_ptr`, `_size`, and `_readonly` fields, implementing `__getbuffer__` / `__releasebuffer__`.

`_SegmentViews` now creates `_BorrowedBufferView(..., readonly=True)` instances instead of `_SegmentView`. No public API change for `to_segment_views()`.

### `_memoryview_borrowing` helper

```cython
from cpython.memoryview cimport PyMemoryView_FromObject

cdef inline object _memoryview_borrowing(object owner, void* ptr,
                                         Py_ssize_t size, bint readonly):
    cdef _BorrowedBufferView exporter
    exporter = _BorrowedBufferView()._init(owner, ptr, size, readonly)
    return PyMemoryView_FromObject(exporter)
```

This establishes the reference chain:

```text
memoryview ──ref──> _BorrowedBufferView ──._owner──> reader/builder ──._parent──> message / payload
```

`mv.obj` now points at the exporter object (not `None`), and lifetime is enforced by standard buffer-protocol reference counting.

### `get_data_as_view()` on reader and builder

DATA field pointer resolution is factored into `_data_field_ptr_reader` and `_data_field_ptr_builder`. Both `get_data_as_view()` methods resolve the field pointer then call `_memoryview_borrowing`:

```cython
# reader (read-only)
_data_field_ptr_reader(self, field, &data_ptr, &data_size)
return _memoryview_borrowing(self, data_ptr, <Py_ssize_t>data_size, True)

# builder (writable)
_data_field_ptr_builder(self, field, &data_ptr, &data_size)
return _memoryview_borrowing(self, data_ptr, <Py_ssize_t>data_size, False)
```

Empty-field handling is unchanged (`data_size == 0 and data_ptr == NULL` →
`_EMPTY_DATA_VIEW_SENTINEL`).

### Owner pinning: struct vs message

- **`to_segment_views()`** exports whole-message segment snapshots → pins `_MessageBuilder`.
- **`get_data_as_view()`** exports a pointer inside a specific struct's DATA field → pins **`self`** (the struct reader/builder):

  ```text
  # packed reader
  mv → exporter → _DynamicStructReader → _PackedMessageReaderBytes → payload

  # builder
  mv → exporter → _DynamicStructBuilder → _MessageBuilder → arena
  ```

### API compatibility

- **`get_data_as_view()`** still returns `memoryview` directly — no breaking change for callers.
- **`to_segment_views()`** still returns a sequence of exporter objects; callers wrap with `memoryview()` as before.

### Files changed

| File | Changes |
|------|---------|
| `capnp/lib/capnp.pyx` | `_BorrowedBufferView`, `_memoryview_borrowing`, `_data_field_ptr_*`, refactor `_SegmentViews`, rewrite both `get_data_as_view()` |
| `test/test_get_data_view.py` | Add lifetime / leak regression tests |

### Structure

```text
_SegmentView  ──generalize──>  _BorrowedBufferView (+ _readonly, _owner)
         │                              ▲
         │                              │
_SegmentViews ──────────────────────────┘  (readonly=True, owner=builder)

get_data_as_view (reader)  ──> _memoryview_borrowing(self, ptr, len, readonly=True)
get_data_as_view (builder) ──> _memoryview_borrowing(self, ptr, len, readonly=False)
```

## Testing

### New regression tests (`test/test_get_data_view.py`)

| Test | What it verifies |
|------|-----------------|
| `test_data_view_exports_through_buffer_exporter` | `view.obj is not None`; exporter length matches view |
| `test_data_view_survives_del_builder` | `del msg` while view alive → view still readable |
| `test_data_view_releases_packed_payload` | after `view.release()` + `del view, reader, payload` → weakref payload is `None` |

Existing tests continue to cover read-only/writable behavior, empty DATA fields, nested structs, wrong field types, and `test_view_keeps_message_alive` (refcount increase via exporter pin).

### Targeted test runs

```bash
python -m pytest test/test_get_data_view.py test/test_serialization.py -q
# 36 passed
```

All segment-view tests pass unchanged, confirming `_BorrowedBufferView` generalization did not regress `to_segment_views()` behavior.

### Full test suite

```bash
python -m pytest test/ -q
```

Run on pycapnp 2.2.4, Python 3.10, WSL2 (with async test deps installed):

| Result | Count |
|--------|-------|
| Passed | 151 |
| Failed | 1 |
| XFailed | 1 |
| Total | 153 |

The single failure is unrelated to this fix:

- `test/test_load.py::test_bundled_import_hook` — `ImportError: cannot import name 'stream_capnp' from 'capnp'`. This is a dev-environment issue: bundled `.capnp` schemas are not on the import path under editable installs. CI/tox runs `pip install .` first and does not hit this.

### Reproducer after fix

Re-running the RSS reproducer from this document on the fixed build:

```text
reader_decode_only:                  +0.08 MiB/iter
reader_get_data_as_view_release:     +0.08 MiB/iter
builder_get_data_as_view_release:    +0.00 MiB/iter

view type: <class 'memoryview'> nbytes: 4194304 obj: <capnp borrowed buffer view ...>
payload alive after reader view release/del: False
```

## Notes

In the buggy build, the returned `memoryview` reported `obj is None`, and explicit `memoryview.release()` did not release the backing owner. The apparent "pinning while `mv` is alive" was largely a side effect of the leaked `PyBuffer_FillInfo` reference, not a correct exporter-backed buffer view.

After the fix, `mv.obj` exposes the internal `_BorrowedBufferView` exporter, and lifetime follows standard Python buffer-protocol semantics: the view pins the struct reader/builder (and thus the message/payload) while alive, and releases it when the view is destroyed.
